### PR TITLE
Resource Loader, unique annotation doesn't prevent conflicts.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ This document outlines best-practices and contributing guidelines to the Quilt S
 The `$` character may be used in mixins to mark a semantic separation in the name,
 in other words it allows to separate the actual name of the variable and the namespace.
 
-`@Unique` fields and methods must be prefixed with `quilt$`.
+`@Unique` fields must be prefixed with `quilt$`, but `@Unique` methods don't need prefixes.
 
 In the case of a pseudo-local variable (a field used briefly to pass around a local variable of a method between 2 injections of said method),
 the field should be named with the namespace first, then the name of the injected method, and finally the name of the local (`quilt$injectedMethod$localName`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+This document outlines best-practices and contributing guidelines to the Quilt Standard Libraries.
+
+## Naming conventions
+
+### Use of the `$` character
+
+The `$` character may be used in mixins to mark a semantic separation in the name,
+in other words it allows to separate the actual name of the variable and the namespace.
+
+`@Unique` fields and methods must be prefixed with `quilt$`.
+
+In the case of a pseudo-local variable (a field used briefly to pass around a local variable of a method between 2 injections of said method),
+the field should be named with the namespace first, then the name of the injected method, and finally the name of the local (`quilt$injectedMethod$localName`).

--- a/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/DefaultResourcePackMixin.java
+++ b/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/DefaultResourcePackMixin.java
@@ -45,11 +45,11 @@ import org.quiltmc.qsl.resource.loader.impl.ResourceLoaderImpl;
 public abstract class DefaultResourcePackMixin {
 	// Redirects all resource access to the MC resource pack.
 	@Unique
-	final ModNioResourcePack quilt$internalPack = this.quilt$locateAndLoad();
+	final ModNioResourcePack quilt$internalPack = this.locateAndLoad();
 
 	@SuppressWarnings({"ConstantConditions", "EqualsBetweenInconvertibleTypes"})
 	@Unique
-	private ModNioResourcePack quilt$locateAndLoad() {
+	private ModNioResourcePack locateAndLoad() {
 		return ResourceLoaderImpl.locateAndLoadDefaultResourcePack(
 				this.getClass().equals(DefaultResourcePack.class) ?
 						ResourceType.SERVER_DATA : ResourceType.CLIENT_RESOURCES

--- a/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/DefaultResourcePackMixin.java
+++ b/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/DefaultResourcePackMixin.java
@@ -45,11 +45,11 @@ import org.quiltmc.qsl.resource.loader.impl.ResourceLoaderImpl;
 public abstract class DefaultResourcePackMixin {
 	// Redirects all resource access to the MC resource pack.
 	@Unique
-	final ModNioResourcePack internalPack = this.locateAndLoad();
+	final ModNioResourcePack quilt$internalPack = this.quilt$locateAndLoad();
 
 	@SuppressWarnings({"ConstantConditions", "EqualsBetweenInconvertibleTypes"})
 	@Unique
-	private ModNioResourcePack locateAndLoad() {
+	private ModNioResourcePack quilt$locateAndLoad() {
 		return ResourceLoaderImpl.locateAndLoadDefaultResourcePack(
 				this.getClass().equals(DefaultResourcePack.class) ?
 						ResourceType.SERVER_DATA : ResourceType.CLIENT_RESOURCES
@@ -62,7 +62,7 @@ public abstract class DefaultResourcePackMixin {
 	 */
 	@Overwrite
 	public boolean contains(ResourceType type, Identifier id) {
-		return this.internalPack.contains(type, id);
+		return this.quilt$internalPack.contains(type, id);
 	}
 
 	/**
@@ -72,7 +72,7 @@ public abstract class DefaultResourcePackMixin {
 	@Overwrite
 	public @Nullable InputStream findInputStream(ResourceType type, Identifier id) {
 		try {
-			return this.internalPack.open(type, id);
+			return this.quilt$internalPack.open(type, id);
 		} catch (IOException e) {
 			return null;
 		}
@@ -85,7 +85,7 @@ public abstract class DefaultResourcePackMixin {
 	@Overwrite
 	public @Nullable InputStream getInputStream(String path) {
 		try {
-			return this.internalPack.openRoot(path);
+			return this.quilt$internalPack.openRoot(path);
 		} catch (IOException e) {
 			return null;
 		}
@@ -98,11 +98,11 @@ public abstract class DefaultResourcePackMixin {
 	@Overwrite
 	public Collection<Identifier> findResources(ResourceType type, String namespace, String prefix, int maxDepth,
 												Predicate<String> pathFilter) {
-		return this.internalPack.findResources(type, namespace, prefix, maxDepth, pathFilter);
+		return this.quilt$internalPack.findResources(type, namespace, prefix, maxDepth, pathFilter);
 	}
 
 	@Inject(method = "close", at = @At("HEAD"), remap = false)
 	private void onClose(CallbackInfo ci) {
-		this.internalPack.close();
+		this.quilt$internalPack.close();
 	}
 }

--- a/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/KeyedResourceReloaderMixin.java
+++ b/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/KeyedResourceReloaderMixin.java
@@ -39,47 +39,47 @@ import org.quiltmc.qsl.resource.loader.api.reloader.ResourceReloaderKeys;
 })
 public abstract class KeyedResourceReloaderMixin implements IdentifiableResourceReloader {
 	@Unique
-	private Identifier id;
+	private Identifier quilt$id;
 	@Unique
-	private Collection<Identifier> dependencies;
+	private Collection<Identifier> quilt$dependencies;
 
 	@Override
 	@SuppressWarnings({"ConstantConditions", "RedundantCast"})
 	public Identifier getQuiltId() {
-		if (this.id == null) {
+		if (this.quilt$id == null) {
 			Object self = this;
 
 			if (self instanceof RecipeManager) {
-				this.id = ResourceReloaderKeys.Server.RECIPES;
+				this.quilt$id = ResourceReloaderKeys.Server.RECIPES;
 			} else if (self instanceof ServerAdvancementLoader) {
-				this.id = ResourceReloaderKeys.Server.ADVANCEMENTS;
+				this.quilt$id = ResourceReloaderKeys.Server.ADVANCEMENTS;
 			} else if (self instanceof FunctionLoader) {
-				this.id = ResourceReloaderKeys.Server.FUNCTIONS;
+				this.quilt$id = ResourceReloaderKeys.Server.FUNCTIONS;
 			} else if (self instanceof LootManager) {
-				this.id = ResourceReloaderKeys.Server.LOOT_TABLES;
+				this.quilt$id = ResourceReloaderKeys.Server.LOOT_TABLES;
 			} else if (self instanceof TagManagerLoader) {
-				this.id = ResourceReloaderKeys.Server.TAGS;
+				this.quilt$id = ResourceReloaderKeys.Server.TAGS;
 			} else {
-				this.id = new Identifier("private/" + self.getClass().getSimpleName().toLowerCase(Locale.ROOT));
+				this.quilt$id = new Identifier("private/" + self.getClass().getSimpleName().toLowerCase(Locale.ROOT));
 			}
 		}
 
-		return this.id;
+		return this.quilt$id;
 	}
 
 	@Override
 	@SuppressWarnings({"ConstantConditions", "RedundantCast"})
 	public Collection<Identifier> getQuiltDependencies() {
-		if (this.dependencies == null) {
+		if (this.quilt$dependencies == null) {
 			Object self = this;
 
 			if (self instanceof TagManagerLoader) {
-				this.dependencies = Collections.emptyList();
+				this.quilt$dependencies = Collections.emptyList();
 			} else {
-				this.dependencies = Collections.singletonList(ResourceReloaderKeys.Server.TAGS);
+				this.quilt$dependencies = Collections.singletonList(ResourceReloaderKeys.Server.TAGS);
 			}
 		}
 
-		return this.dependencies;
+		return this.quilt$dependencies;
 	}
 }

--- a/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/NamespaceResourceManagerMixin.java
+++ b/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/NamespaceResourceManagerMixin.java
@@ -38,6 +38,10 @@ import org.quiltmc.qsl.resource.loader.impl.ResourceLoaderImpl;
 
 @Mixin(NamespaceResourceManager.class)
 public class NamespaceResourceManagerMixin {
+	/**
+	 * Acts as a pseudo-local variable in {@link NamespaceResourceManager#getAllResources(Identifier)}.
+	 * Not thread-safe so a ThreadLocal is required.
+	 */
 	@Unique
 	private final ThreadLocal<List<Resource>> quilt$getAllResources$resources = new ThreadLocal<>();
 

--- a/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/NamespaceResourceManagerMixin.java
+++ b/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/NamespaceResourceManagerMixin.java
@@ -39,7 +39,7 @@ import org.quiltmc.qsl.resource.loader.impl.ResourceLoaderImpl;
 @Mixin(NamespaceResourceManager.class)
 public class NamespaceResourceManagerMixin {
 	@Unique
-	private final ThreadLocal<List<Resource>> getAllResources$resources = new ThreadLocal<>();
+	private final ThreadLocal<List<Resource>> quilt$getAllResources$resources = new ThreadLocal<>();
 
 	@Inject(
 			method = "getAllResources",
@@ -50,7 +50,7 @@ public class NamespaceResourceManagerMixin {
 			locals = LocalCapture.CAPTURE_FAILHARD
 	)
 	private void onGetAllResources(Identifier id, CallbackInfoReturnable<List<Resource>> cir, List<Resource> resources) {
-		this.getAllResources$resources.set(resources);
+		this.quilt$getAllResources$resources.set(resources);
 	}
 
 	@Redirect(
@@ -63,7 +63,7 @@ public class NamespaceResourceManagerMixin {
 	private boolean onResourceAdd(ResourcePack pack, ResourceType type, Identifier id) throws IOException {
 		if (pack instanceof GroupResourcePack groupResourcePack) {
 			ResourceLoaderImpl.appendResourcesFromGroup((NamespaceResourceManagerAccessor) this, id, groupResourcePack,
-					this.getAllResources$resources.get());
+					this.quilt$getAllResources$resources.get());
 			return false;
 		}
 

--- a/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/GameOptionsMixin.java
+++ b/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/GameOptionsMixin.java
@@ -53,12 +53,12 @@ public abstract class GameOptionsMixin {
 	 * This allow to keep track of resource packs that are present but forcefully disabled for built-in resource packs.
 	 */
 	@Unique
-	private List<String> availableResourcePacks = new ArrayList<>();
+	private List<String> quilt$availableResourcePacks = new ArrayList<>();
 
 	@Inject(method = "accept(Lnet/minecraft/client/option/GameOptions$Visitor;)V", at = @At("HEAD"))
 	private void onAccept(GameOptions.Visitor visitor, CallbackInfo ci) {
-		this.availableResourcePacks = visitor.visitObject("quilt_available_resource_packs", this.availableResourcePacks,
-				GameOptionsMixin::parseList, GSON::toJson);
+		this.quilt$availableResourcePacks = visitor.visitObject("quilt_available_resource_packs",
+				this.quilt$availableResourcePacks, GameOptionsMixin::parseList, GSON::toJson);
 	}
 
 	@Inject(method = "addResourcePackProfilesToManager", at = @At("HEAD"))
@@ -66,11 +66,11 @@ public abstract class GameOptionsMixin {
 		var toEnable = new ArrayList<String>();
 
 		// Remove all resource packs that cannot be found from the available resource packs list.
-		this.availableResourcePacks.removeIf(availableResourcePack -> manager.getProfile(availableResourcePack) == null);
+		this.quilt$availableResourcePacks.removeIf(availableResourcePack -> manager.getProfile(availableResourcePack) == null);
 
 		// Update available resource packs.
 		for (var profile : manager.getProfiles()) {
-			if (!this.availableResourcePacks.contains(profile.getName())) {
+			if (!this.quilt$availableResourcePacks.contains(profile.getName())) {
 				if (profile.getSource() == ModResourcePackProvider.PACK_SOURCE_MOD_BUILTIN) {
 					// A built-in resource pack provided by a mod.
 
@@ -82,7 +82,7 @@ public abstract class GameOptionsMixin {
 					}
 				}
 
-				this.availableResourcePacks.add(profile.getName());
+				this.quilt$availableResourcePacks.add(profile.getName());
 			}
 		}
 

--- a/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/KeyedClientResourceReloaderMixin.java
+++ b/library/core/resource-loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/KeyedClientResourceReloaderMixin.java
@@ -43,47 +43,47 @@ import org.quiltmc.qsl.resource.loader.api.reloader.ResourceReloaderKeys;
 })
 public abstract class KeyedClientResourceReloaderMixin implements IdentifiableResourceReloader {
 	@Unique
-	private Identifier id;
+	private Identifier quilt$id;
 	@Unique
-	private Collection<Identifier> dependencies;
+	private Collection<Identifier> quilt$dependencies;
 
 	@Override
 	@SuppressWarnings({"ConstantConditions", "RedundantCast"})
 	public Identifier getQuiltId() {
-		if (this.id == null) {
+		if (this.quilt$id == null) {
 			Object self = this;
 
 			if (self instanceof SoundManager) {
-				this.id = ResourceReloaderKeys.Client.SOUNDS;
+				this.quilt$id = ResourceReloaderKeys.Client.SOUNDS;
 			} else if (self instanceof BakedModelManager) {
-				this.id = ResourceReloaderKeys.Client.MODELS;
+				this.quilt$id = ResourceReloaderKeys.Client.MODELS;
 			} else if (self instanceof LanguageManager) {
-				this.id = ResourceReloaderKeys.Client.LANGUAGES;
+				this.quilt$id = ResourceReloaderKeys.Client.LANGUAGES;
 			} else if (self instanceof TextureManager) {
-				this.id = ResourceReloaderKeys.Client.TEXTURES;
+				this.quilt$id = ResourceReloaderKeys.Client.TEXTURES;
 			} else {
-				this.id = new Identifier("private/" + self.getClass().getSimpleName().toLowerCase(Locale.ROOT));
+				this.quilt$id = new Identifier("private/" + self.getClass().getSimpleName().toLowerCase(Locale.ROOT));
 			}
 		}
 
-		return this.id;
+		return this.quilt$id;
 	}
 
 	@Override
 	@SuppressWarnings({"ConstantConditions", "RedundantCast"})
 	public Collection<Identifier> getQuiltDependencies() {
-		if (this.dependencies == null) {
+		if (this.quilt$dependencies == null) {
 			Object self = this;
 
 			if (self instanceof BakedModelManager || self instanceof WorldRenderer) {
-				this.dependencies = Collections.singletonList(ResourceReloaderKeys.Client.TEXTURES);
+				this.quilt$dependencies = Collections.singletonList(ResourceReloaderKeys.Client.TEXTURES);
 			} else if (self instanceof ItemRenderer || self instanceof BlockRenderManager) {
-				this.dependencies = Collections.singletonList(ResourceReloaderKeys.Client.MODELS);
+				this.quilt$dependencies = Collections.singletonList(ResourceReloaderKeys.Client.MODELS);
 			} else {
-				this.dependencies = Collections.emptyList();
+				this.quilt$dependencies = Collections.emptyList();
 			}
 		}
 
-		return this.dependencies;
+		return this.quilt$dependencies;
 	}
 }


### PR DESCRIPTION
Turns out the `@Unique` annotation doesn't actually prevent conflicts, it only prevents overwriting the field. `@Unique` fields then still should be prefixed for good measure.

This PR adds the prefixes to the `@Unique` fields in resource loader.