### PR TITLE
Lifecycle events

### DIFF
--- a/library/core/lifecycle-events/build.gradle
+++ b/library/core/lifecycle-events/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+	id("qsl.module")
+}
+
+qslModule {
+	moduleName = "lifecycle-events"
+	version = "1.0.0"
+	library = "core"
+	coreDependencies([
+			"qsl-base"
+	])
+}

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientLifecycleEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientLifecycleEvents.java
@@ -1,0 +1,97 @@
+package org.quiltmc.qsl.lifecycle.api.client.event;
+
+import org.quiltmc.qsl.base.api.event.ArrayEvent;
+
+import net.minecraft.client.MinecraftClient;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+/**
+ * Events indicating the lifecycle of a Minecraft client.
+ *
+ * <p>The lifecycle of a Minecraft client, starts when the client is ready. The client will tick the client and then the
+ * integrated server if in single player.
+ *
+ * @see ClientTickEvents
+ */
+@Environment(EnvType.CLIENT)
+public final class ClientLifecycleEvents {
+	// There is no CLIENT_STARTING event because there is no way to allow mods to register callbacks that early without
+	// possibly initializing the game's registries improperly in preLaunch.
+
+	/**
+	 * An event indicating that a Minecraft client is ready to tick and render.
+	 *
+	 * <p>It should be noted this event is executed while the splash screen is visible, not the main menu.
+	 */
+	public static final ArrayEvent<Ready> READY = ArrayEvent.create(Ready.class, callbacks -> client -> {
+		for (var callback : callbacks) {
+			callback.readyClient(client);
+		}
+	});
+
+	/**
+	 * An event indicating that a Minecraft client has finished it's last tick and will shut down.
+	 *
+	 * <p>If the client is connected to a server, the client will disconnect from the server. Then if the client has a
+	 * running an integrated server, the integrated server will be shutdown. Finally all client facilities are torn down.
+	 *
+	 * <h2>What should mods do when this event is executed</h2>
+	 *
+	 * Mods which maintain session data when connected to a server should should save that data here as those mods still
+	 * have access to the connected server.
+	 *
+	 * <p>If your mod has any data on the integrated server, avoid doing that here, use
+	 * {@link org.quiltmc.qsl.lifecycle.api.event.ServerLifecycleEvents#STOPPING ServerLifecycleEvents.SERVER_STOPPING}
+	 * instead to clean up any data on the integrated server.
+	 */
+	public static final ArrayEvent<Stopping> STOPPING = ArrayEvent.create(Stopping.class, callbacks -> client -> {
+		for (var callback : callbacks) {
+			callback.stoppingClient(client);
+		}
+	});
+
+	/**
+	 * An event indicating the client has finished shutdown and will exit.
+	 *
+	 * <p>The Java Virtual Machine will terminate after this event is executed.
+	 */
+	public static final ArrayEvent<Stopped> STOPPED = ArrayEvent.create(Stopped.class, callbacks -> client -> {
+		for (var callback : callbacks) {
+			callback.stoppedClient(client);
+		}
+	});
+
+	private ClientLifecycleEvents() {}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #READY}.
+	 * @see #READY
+	 */
+	@FunctionalInterface
+	@Environment(EnvType.CLIENT)
+	public interface Ready {
+		void readyClient(MinecraftClient client);
+	}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #STOPPING}.
+	 * @see #STOPPING
+	 */
+	@FunctionalInterface
+	@Environment(EnvType.CLIENT)
+	public interface Stopping {
+		void stoppingClient(MinecraftClient client);
+	}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #STOPPED}.
+	 * @see #STOPPED
+	 */
+	@FunctionalInterface
+	@Environment(EnvType.CLIENT)
+	public interface Stopped {
+		void stoppedClient(MinecraftClient client);
+	}
+}

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientLifecycleEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientLifecycleEvents.java
@@ -28,13 +28,11 @@ import net.fabricmc.api.Environment;
  *
  * <p>The lifecycle of a Minecraft client, starts when the client is ready. The client will tick the client and then the
  * integrated server if in single player.
- *
- * @see ClientTickEvents
  */
 @Environment(EnvType.CLIENT)
 public final class ClientLifecycleEvents {
-	// There is no CLIENT_STARTING event because there is no way to allow mods to register callbacks that early without
-	// possibly initializing the game's registries improperly in preLaunch.
+	// There is no STARTING event because there is no way to allow mods to register callbacks that early without possibly
+	// initializing the game's registries improperly in preLaunch.
 
 	/**
 	 * An event indicating that a Minecraft client is ready to tick and render.

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientLifecycleEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientLifecycleEvents.java
@@ -46,14 +46,14 @@ public final class ClientLifecycleEvents {
 	});
 
 	/**
-	 * An event indicating that a Minecraft client has finished it's last tick and will shut down.
+	 * An event indicating that a Minecraft client has finished its last tick and will shut down.
 	 *
-	 * <p>If the client is connected to a server, the client will disconnect from the server. Then if the client has a
-	 * running an integrated server, the integrated server will be shutdown. Finally all client facilities are torn down.
+	 * <p>After this event is fired, the client will disconnect from the server if it is connected to one. Then, if the client
+	 * was running an integrated server, the integrated server will be shut down. Finally, all client facilities are torn down.
 	 *
-	 * <h2>What should mods do when this event is executed</h2>
+	 * <h2>What should mods do when this event is executed?</h2>
 	 *
-	 * Mods which maintain session data when connected to a server should should save that data here as those mods still
+	 * Mods which maintain session data when connected to a server should save that data here, as the client will still
 	 * have access to the connected server.
 	 *
 	 * <p>If your mod has any data on the integrated server, avoid doing that here, use
@@ -104,7 +104,7 @@ public final class ClientLifecycleEvents {
 	@Environment(EnvType.CLIENT)
 	public interface Stopping {
 		/**
-		 * Called when a Minecraft client has finished it's last tick and is shutting down.
+		 * Called when a Minecraft client has finished its last tick and is shutting down.
 		 *
 		 * @param client the client which is shutting down
 		 */

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientLifecycleEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientLifecycleEvents.java
@@ -43,7 +43,7 @@ public final class ClientLifecycleEvents {
 	 * have access to the connected server.
 	 *
 	 * <p>If your mod has any data on the integrated server, avoid doing that here, use
-	 * {@link org.quiltmc.qsl.lifecycle.api.event.ServerLifecycleEvents#STOPPING ServerLifecycleEvents.SERVER_STOPPING}
+	 * {@link org.quiltmc.qsl.lifecycle.api.event.ServerLifecycleEvents#STOPPING ServerLifecycleEvents.STOPPING}
 	 * instead to clean up any data on the integrated server.
 	 */
 	public static final ArrayEvent<Stopping> STOPPING = ArrayEvent.create(Stopping.class, callbacks -> client -> {

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientLifecycleEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientLifecycleEvents.java
@@ -86,6 +86,13 @@ public final class ClientLifecycleEvents {
 	@FunctionalInterface
 	@Environment(EnvType.CLIENT)
 	public interface Ready {
+		/**
+		 * Called when a majority of client facilities have been initialized.
+		 *
+		 * <p>It should be noted this is executed while the splash screen is visible, not when the main menu is reached.
+		 *
+		 * @param client the client which is read.
+		 */
 		void readyClient(MinecraftClient client);
 	}
 
@@ -96,6 +103,11 @@ public final class ClientLifecycleEvents {
 	@FunctionalInterface
 	@Environment(EnvType.CLIENT)
 	public interface Stopping {
+		/**
+		 * Called when a Minecraft client has finished it's last tick and is shutting down.
+		 *
+		 * @param client the client which is shutting down
+		 */
 		void stoppingClient(MinecraftClient client);
 	}
 
@@ -106,6 +118,13 @@ public final class ClientLifecycleEvents {
 	@FunctionalInterface
 	@Environment(EnvType.CLIENT)
 	public interface Stopped {
+		/**
+		 * Called when a Minecraft client has finished shutdown and the client will be exited.
+		 *
+		 * <p>This is typically executed just before the Java virtual machine is shut down.
+		 *
+		 * @param client the minecraft client which is exiting
+		 */
 		void stoppedClient(MinecraftClient client);
 	}
 }

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientLifecycleEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientLifecycleEvents.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.lifecycle.api.client.event;
 
 import org.quiltmc.qsl.base.api.event.ArrayEvent;

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientTickEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientTickEvents.java
@@ -1,0 +1,62 @@
+package org.quiltmc.qsl.lifecycle.api.client.event;
+
+import org.quiltmc.qsl.base.api.event.ArrayEvent;
+
+import net.minecraft.client.MinecraftClient;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+/**
+ * Events indicating progress through the tick loop of a Minecraft client.
+ *
+ * <h2>A note of warning</h2>
+ *
+ * Callbacks registered to any of these events should ensure as little time as possible is spent executing, since the tick
+ * loop is a very hot code path.
+ */
+@Environment(EnvType.CLIENT)
+public final class ClientTickEvents {
+	/**
+	 * An event indicating an iteration of the client's tick loop will start.
+	 */
+	public static final ArrayEvent<Start> START = ArrayEvent.create(Start.class, callbacks -> client -> {
+		for (var callback : callbacks) {
+			callback.startClientTick(client);
+		}
+	});
+
+	/**
+	 * An event indicating the client has finished an iteration of the tick loop.
+	 *
+	 * <p>Since there will be a time gap before the next tick, this is a great spot to run any asynchronous operations
+	 * for the next tick.
+	 */
+	public static final ArrayEvent<End> END = ArrayEvent.create(End.class, callbacks -> client -> {
+		for (var callback : callbacks) {
+			callback.endClientTick(client);
+		}
+	});
+
+	private ClientTickEvents() {}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #START}.
+	 * @see #START
+	 */
+	@FunctionalInterface
+	@Environment(EnvType.CLIENT)
+	public interface Start {
+		void startClientTick(MinecraftClient client);
+	}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #END}.
+	 * @see #END
+	 */
+	@FunctionalInterface
+	@Environment(EnvType.CLIENT)
+	public interface End {
+		void endClientTick(MinecraftClient client);
+	}
+}

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientTickEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientTickEvents.java
@@ -63,6 +63,11 @@ public final class ClientTickEvents {
 	@FunctionalInterface
 	@Environment(EnvType.CLIENT)
 	public interface Start {
+		/**
+		 * Called before the client has started an iteration of the tick loop.
+		 *
+		 * @param client the client
+		 */
 		void startClientTick(MinecraftClient client);
 	}
 
@@ -73,6 +78,11 @@ public final class ClientTickEvents {
 	@FunctionalInterface
 	@Environment(EnvType.CLIENT)
 	public interface End {
+		/**
+		 * Called at the end of an iteration of the client's tick loop.
+		 *
+		 * @param client the client that finished ticking
+		 */
 		void endClientTick(MinecraftClient client);
 	}
 }

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientTickEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientTickEvents.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.lifecycle.api.client.event;
 
 import org.quiltmc.qsl.base.api.event.ArrayEvent;

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientWorldTickEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientWorldTickEvents.java
@@ -24,6 +24,14 @@ import net.minecraft.client.world.ClientWorld;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
+/**
+ * Events related to a ticking Minecraft client's world.
+ *
+ * <h2>A note of warning</h2>
+ *
+ * Callbacks registered to any of these events should ensure as little time as possible is spent executing, since the tick
+ * loop is a very hot code path.
+ */
 @Environment(EnvType.CLIENT)
 public final class ClientWorldTickEvents {
 	/**
@@ -53,6 +61,12 @@ public final class ClientWorldTickEvents {
 	@FunctionalInterface
 	@Environment(EnvType.CLIENT)
 	public interface Start {
+		/**
+		 * Called before a world is ticked.
+		 *
+		 * @param client the client
+		 * @param world the world being ticked
+		 */
 		void startWorldTick(MinecraftClient client, ClientWorld world);
 	}
 
@@ -63,6 +77,12 @@ public final class ClientWorldTickEvents {
 	@FunctionalInterface
 	@Environment(EnvType.CLIENT)
 	public interface End {
+		/**
+		 * Called after a world is ticked.
+		 *
+		 * @param client the client
+		 * @param world the world being ticked
+		 */
 		void endWorldTick(MinecraftClient client, ClientWorld world);
 	}
 }

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientWorldTickEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientWorldTickEvents.java
@@ -1,0 +1,52 @@
+package org.quiltmc.qsl.lifecycle.api.client.event;
+
+import org.quiltmc.qsl.base.api.event.ArrayEvent;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.world.ClientWorld;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+@Environment(EnvType.CLIENT)
+public final class ClientWorldTickEvents {
+	/**
+	 * An event indicating that a world will be ticked.
+	 */
+	public static final ArrayEvent<Start> START = ArrayEvent.create(Start.class, callbacks -> (client, world) -> {
+		for (var callback : callbacks) {
+			callback.startWorldTick(client, world);
+		}
+	});
+
+	/**
+	 * An event indicating that a world has finished being ticked.
+	 */
+	public static final ArrayEvent<End> END = ArrayEvent.create(End.class, callbacks -> (client, world) -> {
+		for (var callback : callbacks) {
+			callback.endWorldTick(client, world);
+		}
+	});
+
+	private ClientWorldTickEvents() {}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #START}.
+	 * @see #START
+	 */
+	@FunctionalInterface
+	@Environment(EnvType.CLIENT)
+	public interface Start {
+		void startWorldTick(MinecraftClient client, ClientWorld world);
+	}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #END}.
+	 * @see #END
+	 */
+	@FunctionalInterface
+	@Environment(EnvType.CLIENT)
+	public interface End {
+		void endWorldTick(MinecraftClient client, ClientWorld world);
+	}
+}

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientWorldTickEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/ClientWorldTickEvents.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.lifecycle.api.client.event;
 
 import org.quiltmc.qsl.base.api.event.ArrayEvent;

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/package-info.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/client/event/package-info.java
@@ -1,0 +1,29 @@
+/**
+ * Events to track the lifecycle of a Minecraft client.
+ *
+ * <p>The events in this package pertain to the logical Minecraft client, which handles input and output, rendering,
+ * connections to a server and starting/stopping the client's own integrated server. A Minecraft client operates using a
+ * tick loop and events are executed as the tick loop runs.
+ *
+ * <h2>The Minecraft client singleton and lifecycle events</h2>
+ *
+ * The {@link net.minecraft.client.MinecraftClient#getInstance() Minecraft client singleton} may be accessed at any time
+ * during mod initialization, however the singleton will be in an incomplete state during mod initialization.
+ * Many client facilities will not be completely setup at that point. The lifecycle events in this package are useful
+ * for be notified when most client facilities have been initialized and therefore can be safely interfaced with.
+ *
+ * <p>The events in {@link org.quiltmc.qsl.lifecycle.api.client.event.ClientLifecycleEvents} are executed during client
+ * initialization or shutdown.
+ *
+ * <p>The events in {@link org.quiltmc.qsl.lifecycle.api.client.event.ClientTickEvents} are executed as the tick loop is
+ * iterated.
+ *
+ * <p>To track initialization and shutdown of the client's integrated server, use
+ * {@link org.quiltmc.qsl.lifecycle.api.event.ServerLifecycleEvents}.
+ *
+ * @see org.quiltmc.qsl.lifecycle.api.client.event.ClientLifecycleEvents
+ * @see org.quiltmc.qsl.lifecycle.api.client.event.ClientTickEvents
+ * @see org.quiltmc.qsl.lifecycle.api.client.event.ClientWorldTickEvents
+ */
+
+package org.quiltmc.qsl.lifecycle.api.client.event;

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerLifecycleEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerLifecycleEvents.java
@@ -20,6 +20,9 @@ import org.quiltmc.qsl.base.api.event.ArrayEvent;
 
 import net.minecraft.server.MinecraftServer;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
 /**
  * Events indicating the lifecycle of a Minecraft server.
  *
@@ -44,9 +47,9 @@ public final class ServerLifecycleEvents {
 	 * <p>This is the first event fired in the lifecycle of a Minecraft server. It should be noted at this point that
 	 * the server has no registered player manager, or worlds.
 	 */
-	public static final ArrayEvent<Starting> SERVER_STARTING = ArrayEvent.create(Starting.class, callbacks -> server -> {
+	public static final ArrayEvent<Starting> STARTING = ArrayEvent.create(Starting.class, callbacks -> server -> {
 		for (var callback : callbacks) {
-			callback.serverStarting(server);
+			callback.startingServer(server);
 		}
 	});
 
@@ -58,9 +61,9 @@ public final class ServerLifecycleEvents {
 	 *
 	 * <p>After this event finishes, the server will tick for the first time.
 	 */
-	public static final ArrayEvent<Ready> SERVER_READY = ArrayEvent.create(Ready.class, callbacks -> server -> {
+	public static final ArrayEvent<Ready> READY = ArrayEvent.create(Ready.class, callbacks -> server -> {
 		for (var callback : callbacks) {
-			callback.serverReady(server);
+			callback.readyServer(server);
 		}
 	});
 
@@ -77,17 +80,17 @@ public final class ServerLifecycleEvents {
 	 * Mods may do clean up work when this event is executed, such as shutting down any asynchronous executors,
 	 * databases and saving auxiliary mod data.
 	 */
-	public static final ArrayEvent<Stopping> SERVER_STOPPING = ArrayEvent.create(Stopping.class, callbacks -> server -> {
+	public static final ArrayEvent<Stopping> STOPPING = ArrayEvent.create(Stopping.class, callbacks -> server -> {
 		for (var callback : callbacks) {
-			callback.serverStopping(server);
+			callback.stoppingServer(server);
 		}
 	});
 
 	/**
-	 * An event indicating that a Minecraft server has finished shutting down and will exit.
+	 * An event indicating that a Minecraft server has finished shutting down.
 	 *
-	 * <p>The meaning of "exit" will vary depending on whether the Minecraft server is a dedicated server or the integrated
-	 * server of a Minecraft client:
+	 * <p>What occurs after this event will vary depending on whether the Minecraft server is a dedicated server or the
+	 * integrated server of a Minecraft client:
 	 *
 	 * <ul>
 	 * <li><b>integrated server:</b> the client will continue to tick after this event is executed. If the client is being
@@ -101,17 +104,17 @@ public final class ServerLifecycleEvents {
 	 * heap and will leak memory. Though this doesn't matter when the server is a dedicated server, it is good principle
 	 * to clean up references you no longer need regardless.
 	 */
-	public static final ArrayEvent<Exit> SERVER_EXIT = ArrayEvent.create(Exit.class, callbacks -> server -> {
+	public static final ArrayEvent<Stopped> STOPPED = ArrayEvent.create(Stopped.class, callbacks -> server -> {
 		for (var callback : callbacks) {
-			callback.serverExit(server);
+			callback.exitServer(server);
 		}
 	});
 
 	private ServerLifecycleEvents() {}
 
 	/**
-	 * Functional interface to be implemented on callbacks for {@link #SERVER_STARTING}.
-	 * @see #SERVER_STARTING
+	 * Functional interface to be implemented on callbacks for {@link #STARTING}.
+	 * @see #STARTING
 	 */
 	@FunctionalInterface
 	public interface Starting {
@@ -120,12 +123,12 @@ public final class ServerLifecycleEvents {
 		 *
 		 * @param server the server which is starting
 		 */
-		void serverStarting(MinecraftServer server);
+		void startingServer(MinecraftServer server);
 	}
 
 	/**
-	 * Functional interface to be implemented on callbacks for {@link #SERVER_READY}.
-	 * @see #SERVER_READY
+	 * Functional interface to be implemented on callbacks for {@link #READY}.
+	 * @see #READY
 	 */
 	@FunctionalInterface
 	public interface Ready {
@@ -134,12 +137,12 @@ public final class ServerLifecycleEvents {
 		 *
 		 * @param server the server which is ready
 		 */
-		void serverReady(MinecraftServer server);
+		void readyServer(MinecraftServer server);
 	}
 
 	/**
-	 * Functional interface to be implemented on callbacks for {@link #SERVER_STOPPING}.
-	 * @see #SERVER_STOPPING
+	 * Functional interface to be implemented on callbacks for {@link #STOPPING}.
+	 * @see #STOPPING
 	 */
 	@FunctionalInterface
 	public interface Stopping {
@@ -148,19 +151,20 @@ public final class ServerLifecycleEvents {
 		 *
 		 * @param server the server which is shutting down
 		 */
-		void serverStopping(MinecraftServer server);
+		void stoppingServer(MinecraftServer server);
 	}
 
 	/**
-	 * Functional interface to be implemented on callbacks for {@link #SERVER_EXIT}.
-	 * @see #SERVER_EXIT
+	 * Functional interface to be implemented on callbacks for {@link #STOPPED}.
+	 * @see #STOPPED
 	 */
-	public interface Exit {
+	@Environment(EnvType.CLIENT)
+	public interface Stopped {
 		/**
 		 * Called when a Minecraft server has finished shutdown and the server will be exited.
 		 *
 		 * @param server the minecraft server which is exiting
 		 */
-		void serverExit(MinecraftServer server);
+		void exitServer(MinecraftServer server);
 	}
 }

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerLifecycleEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerLifecycleEvents.java
@@ -20,9 +20,6 @@ import org.quiltmc.qsl.base.api.event.ArrayEvent;
 
 import net.minecraft.server.MinecraftServer;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
 /**
  * Events indicating the lifecycle of a Minecraft server.
  *
@@ -147,7 +144,7 @@ public final class ServerLifecycleEvents {
 	@FunctionalInterface
 	public interface Stopping {
 		/**
-		 * Called when a Minecraft server has finished it's last tick and is shutting down.
+		 * Called when a Minecraft server has finished its last tick and is shutting down.
 		 *
 		 * @param server the server which is shutting down
 		 */
@@ -158,7 +155,7 @@ public final class ServerLifecycleEvents {
 	 * Functional interface to be implemented on callbacks for {@link #STOPPED}.
 	 * @see #STOPPED
 	 */
-	@Environment(EnvType.CLIENT)
+	@FunctionalInterface
 	public interface Stopped {
 		/**
 		 * Called when a Minecraft server has finished shutdown and the server will be exited.

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerTickEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerTickEvents.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.lifecycle.api.event;
+
+import org.quiltmc.qsl.base.api.event.ArrayEvent;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+
+/**
+ * Events indicating progress through the tick loop of a Minecraft server.
+ *
+ * <p>Events in the class are useful for mods which may need to do processing before or after tick of a Minecraft
+ * server.
+ *
+ * <h2>A note of warning</h2>
+ *
+ * Callbacks registered to any of these events should ensure as little time as possible is spent executing, since the tick
+ * loop is a very hot code path.
+ */
+public final class ServerTickEvents {
+	/**
+	 * An event indicating an iteration of the server's tick loop will start.
+	 */
+	public static final ArrayEvent<StartTick> START_SERVER_TICK = ArrayEvent.create(StartTick.class, callbacks -> server -> {
+		for (var callback : callbacks) {
+			callback.startServerTick(server);
+		}
+	});
+
+	/**
+	 * An event indicating that a world will be ticked.
+	 */
+	public static final ArrayEvent<StartWorldTick> START_WORLD_TICK = ArrayEvent.create(StartWorldTick.class, callbacks -> (server, world) -> {
+		for (var callback : callbacks) {
+			callback.startWorldTick(server, world);
+		}
+	});
+
+	/**
+	 * An event indicating that a world has finished being ticked.
+	 */
+	public static final ArrayEvent<EndWorldTick> END_WORLD_TICK = ArrayEvent.create(EndWorldTick.class, callbacks -> (server, world) -> {
+		for (var callback : callbacks) {
+			callback.endWorldTick(server, world);
+		}
+	});
+
+	/**
+	 * An event indicating the server has finished an iteration of the tick loop.
+	 *
+	 * <p>Since there will be a time gap before the next tick, this is a great spot to run any asynchronous operations
+	 * for the next tick.
+	 */
+	public static final ArrayEvent<EndTick> END_SERVER_TICK = ArrayEvent.create(EndTick.class, callbacks -> server -> {
+		for (var callback : callbacks) {
+			callback.endServerTick(server);
+		}
+	});
+
+	private ServerTickEvents() {}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #START_SERVER_TICK}.
+	 * @see #START_SERVER_TICK
+	 */
+	@FunctionalInterface
+	public interface StartTick {
+		/**
+		 * Called before the server has started an iteration of the tick loop.
+		 *
+		 * @param server the server
+		 */
+		void startServerTick(MinecraftServer server);
+	}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #START_WORLD_TICK}.
+	 * @see #START_WORLD_TICK
+	 */
+	@FunctionalInterface
+	public interface StartWorldTick {
+		/**
+		 * Called before a world is ticked.
+		 *
+		 * @param server the server
+		 * @param world the world being ticked
+		 */
+		void startWorldTick(MinecraftServer server, ServerWorld world);
+	}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #END_WORLD_TICK}.
+	 * @see #END_WORLD_TICK
+	 */
+	@FunctionalInterface
+	public interface EndWorldTick {
+		/**
+		 * Called after a world is ticked.
+		 *
+		 * @param server the server
+		 * @param world the world that was ticked
+		 */
+		void endWorldTick(MinecraftServer server, ServerWorld world);
+	}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #END_SERVER_TICK}.
+	 * @see #END_SERVER_TICK
+	 */
+	@FunctionalInterface
+	public interface EndTick {
+		/**
+		 * Called at the end of an iteration of the server's tick loop.
+		 *
+		 * @param server the server that finished ticking
+		 */
+		void endServerTick(MinecraftServer server);
+	}
+}

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerTickEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerTickEvents.java
@@ -19,7 +19,6 @@ package org.quiltmc.qsl.lifecycle.api.event;
 import org.quiltmc.qsl.base.api.event.ArrayEvent;
 
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.world.ServerWorld;
 
 /**
  * Events indicating progress through the tick loop of a Minecraft server.
@@ -36,27 +35,9 @@ public final class ServerTickEvents {
 	/**
 	 * An event indicating an iteration of the server's tick loop will start.
 	 */
-	public static final ArrayEvent<StartTick> START_SERVER_TICK = ArrayEvent.create(StartTick.class, callbacks -> server -> {
+	public static final ArrayEvent<Start> START = ArrayEvent.create(Start.class, callbacks -> server -> {
 		for (var callback : callbacks) {
 			callback.startServerTick(server);
-		}
-	});
-
-	/**
-	 * An event indicating that a world will be ticked.
-	 */
-	public static final ArrayEvent<StartWorldTick> START_WORLD_TICK = ArrayEvent.create(StartWorldTick.class, callbacks -> (server, world) -> {
-		for (var callback : callbacks) {
-			callback.startWorldTick(server, world);
-		}
-	});
-
-	/**
-	 * An event indicating that a world has finished being ticked.
-	 */
-	public static final ArrayEvent<EndWorldTick> END_WORLD_TICK = ArrayEvent.create(EndWorldTick.class, callbacks -> (server, world) -> {
-		for (var callback : callbacks) {
-			callback.endWorldTick(server, world);
 		}
 	});
 
@@ -66,7 +47,7 @@ public final class ServerTickEvents {
 	 * <p>Since there will be a time gap before the next tick, this is a great spot to run any asynchronous operations
 	 * for the next tick.
 	 */
-	public static final ArrayEvent<EndTick> END_SERVER_TICK = ArrayEvent.create(EndTick.class, callbacks -> server -> {
+	public static final ArrayEvent<End> END = ArrayEvent.create(End.class, callbacks -> server -> {
 		for (var callback : callbacks) {
 			callback.endServerTick(server);
 		}
@@ -75,11 +56,11 @@ public final class ServerTickEvents {
 	private ServerTickEvents() {}
 
 	/**
-	 * Functional interface to be implemented on callbacks for {@link #START_SERVER_TICK}.
-	 * @see #START_SERVER_TICK
+	 * Functional interface to be implemented on callbacks for {@link #START}.
+	 * @see #START
 	 */
 	@FunctionalInterface
-	public interface StartTick {
+	public interface Start {
 		/**
 		 * Called before the server has started an iteration of the tick loop.
 		 *
@@ -89,41 +70,11 @@ public final class ServerTickEvents {
 	}
 
 	/**
-	 * Functional interface to be implemented on callbacks for {@link #START_WORLD_TICK}.
-	 * @see #START_WORLD_TICK
+	 * Functional interface to be implemented on callbacks for {@link #END}.
+	 * @see #END
 	 */
 	@FunctionalInterface
-	public interface StartWorldTick {
-		/**
-		 * Called before a world is ticked.
-		 *
-		 * @param server the server
-		 * @param world the world being ticked
-		 */
-		void startWorldTick(MinecraftServer server, ServerWorld world);
-	}
-
-	/**
-	 * Functional interface to be implemented on callbacks for {@link #END_WORLD_TICK}.
-	 * @see #END_WORLD_TICK
-	 */
-	@FunctionalInterface
-	public interface EndWorldTick {
-		/**
-		 * Called after a world is ticked.
-		 *
-		 * @param server the server
-		 * @param world the world that was ticked
-		 */
-		void endWorldTick(MinecraftServer server, ServerWorld world);
-	}
-
-	/**
-	 * Functional interface to be implemented on callbacks for {@link #END_SERVER_TICK}.
-	 * @see #END_SERVER_TICK
-	 */
-	@FunctionalInterface
-	public interface EndTick {
+	public interface End {
 		/**
 		 * Called at the end of an iteration of the server's tick loop.
 		 *

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldLoadEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldLoadEvents.java
@@ -24,7 +24,7 @@ import net.minecraft.server.world.ServerWorld;
 /**
  * Events indicating whether a world has been loaded or unloaded from a server.
  *
- * <p>Mods which implement dynamically loading and unloading worlds from a server may call execute these events to allow
+ * <p>Mods which implement dynamically loading and unloading worlds from a server may execute these events to allow
  * mods to initialize state on new worlds or clean up references to a world.
  */
 public final class ServerWorldLoadEvents {

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldLoadEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldLoadEvents.java
@@ -34,7 +34,7 @@ public final class ServerWorldLoadEvents {
 	 * <p>This event is typically executed at server initialization, but may be called at any time if any mods dynamically
 	 * load worlds.
 	 */
-	public static final ArrayEvent<Load> LOAD_WORLD = ArrayEvent.create(Load.class, callbacks -> (server, world) -> {
+	public static final ArrayEvent<Load> LOAD = ArrayEvent.create(Load.class, callbacks -> (server, world) -> {
 		for (var callback : callbacks) {
 			callback.loadWorld(server, world);
 		}
@@ -46,7 +46,7 @@ public final class ServerWorldLoadEvents {
 	 * <p>This event is typically executed at server shutdown, but may be called at any time if any mods dynamically
 	 * unload worlds.
 	 */
-	public static final ArrayEvent<Unload> UNLOAD_WORLD = ArrayEvent.create(Unload.class, callbacks -> ((server, world) -> {
+	public static final ArrayEvent<Unload> UNLOAD = ArrayEvent.create(Unload.class, callbacks -> ((server, world) -> {
 		for (var callback : callbacks) {
 			callback.unloadWorld(server, world);
 		}
@@ -55,8 +55,8 @@ public final class ServerWorldLoadEvents {
 	private ServerWorldLoadEvents() {}
 
 	/**
-	 * Functional interface to be implemented on callbacks for {@link #LOAD_WORLD}.
-	 * @see #LOAD_WORLD
+	 * Functional interface to be implemented on callbacks for {@link #LOAD}.
+	 * @see #LOAD
 	 */
 	@FunctionalInterface
 	public interface Load {
@@ -64,8 +64,8 @@ public final class ServerWorldLoadEvents {
 	}
 
 	/**
-	 * Functional interface to be implemented on callbacks for {@link #UNLOAD_WORLD}.
-	 * @see #UNLOAD_WORLD
+	 * Functional interface to be implemented on callbacks for {@link #UNLOAD}.
+	 * @see #UNLOAD
 	 */
 	@FunctionalInterface
 	public interface Unload {

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldLoadEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldLoadEvents.java
@@ -32,7 +32,7 @@ public final class ServerWorldLoadEvents {
 	 * Called when a world is loaded onto a Minecraft server.
 	 *
 	 * <p>This event is typically executed at server initialization, but may be called at any time if any mods dynamically
-	 * load worlds.
+	 * load worlds. Mods which wish to add worlds while the server are running are expected to execute this event.
 	 */
 	public static final ArrayEvent<Load> LOAD = ArrayEvent.create(Load.class, callbacks -> (server, world) -> {
 		for (var callback : callbacks) {
@@ -44,7 +44,7 @@ public final class ServerWorldLoadEvents {
 	 * Called when a world is unloaded from a Minecraft server.
 	 *
 	 * <p>This event is typically executed at server shutdown, but may be called at any time if any mods dynamically
-	 * unload worlds.
+	 * unload worlds. Mods which wish to remove worlds while the server are running are expected to execute this event.
 	 */
 	public static final ArrayEvent<Unload> UNLOAD = ArrayEvent.create(Unload.class, callbacks -> ((server, world) -> {
 		for (var callback : callbacks) {
@@ -60,6 +60,14 @@ public final class ServerWorldLoadEvents {
 	 */
 	@FunctionalInterface
 	public interface Load {
+		/**
+		 * Called when a world is loaded onto a Minecraft server.
+		 *
+		 * <p>Mods which maintain per world state may use this event to initialize any required state for this world.
+		 *
+		 * @param server the server the world belongs to
+		 * @param world the world that was loaded
+		 */
 		void loadWorld(MinecraftServer server, ServerWorld world);
 	}
 
@@ -69,6 +77,14 @@ public final class ServerWorldLoadEvents {
 	 */
 	@FunctionalInterface
 	public interface Unload {
+		/**
+		 * Called when a world is unloaded from a Minecraft server.
+		 *
+		 * <p>Mods which maintain per world state should save and clean up any state they have attached to the world.
+		 *
+		 * @param server the server the world was unloaded from
+		 * @param world the world which was unloaded
+		 */
 		void unloadWorld(MinecraftServer server, ServerWorld world);
 	}
 }

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldLoadEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldLoadEvents.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.lifecycle.api.event;
+
+import org.quiltmc.qsl.base.api.event.ArrayEvent;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+
+/**
+ * Events indicating whether a world has been loaded or unloaded from a server.
+ *
+ * <p>Mods which implement dynamically loading and unloading worlds from a server may call execute these events to allow
+ * mods to initialize state on new worlds or clean up references to a world.
+ */
+public final class ServerWorldLoadEvents {
+	/**
+	 * Called when a world is loaded onto a Minecraft server.
+	 *
+	 * <p>This event is typically executed at server initialization, but may be called at any time if any mods dynamically
+	 * load worlds.
+	 */
+	public static final ArrayEvent<Load> LOAD_WORLD = ArrayEvent.create(Load.class, callbacks -> (server, world) -> {
+		for (var callback : callbacks) {
+			callback.loadWorld(server, world);
+		}
+	});
+
+	/**
+	 * Called when a world is unloaded from a Minecraft server.
+	 *
+	 * <p>This event is typically executed at server shutdown, but may be called at any time if any mods dynamically
+	 * unload worlds.
+	 */
+	public static final ArrayEvent<Unload> UNLOAD_WORLD = ArrayEvent.create(Unload.class, callbacks -> ((server, world) -> {
+		for (var callback : callbacks) {
+			callback.unloadWorld(server, world);
+		}
+	}));
+
+	private ServerWorldLoadEvents() {}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #LOAD_WORLD}.
+	 * @see #LOAD_WORLD
+	 */
+	@FunctionalInterface
+	public interface Load {
+		void loadWorld(MinecraftServer server, ServerWorld world);
+	}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #UNLOAD_WORLD}.
+	 * @see #UNLOAD_WORLD
+	 */
+	@FunctionalInterface
+	public interface Unload {
+		void unloadWorld(MinecraftServer server, ServerWorld world);
+	}
+}

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldTickEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldTickEvents.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.lifecycle.api.event;
 
 import org.quiltmc.qsl.base.api.event.ArrayEvent;

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldTickEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldTickEvents.java
@@ -5,10 +5,6 @@ import org.quiltmc.qsl.base.api.event.ArrayEvent;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
-@Environment(EnvType.CLIENT)
 public final class ServerWorldTickEvents {
 	/**
 	 * An event indicating that a world will be ticked.
@@ -35,7 +31,6 @@ public final class ServerWorldTickEvents {
 	 * @see #START
 	 */
 	@FunctionalInterface
-	@Environment(EnvType.CLIENT)
 	public interface Start {
 		/**
 		 * Called before a world is ticked.
@@ -51,7 +46,6 @@ public final class ServerWorldTickEvents {
 	 * @see #END
 	 */
 	@FunctionalInterface
-	@Environment(EnvType.CLIENT)
 	public interface End {
 		/**
 		 * Called after a world is ticked.

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldTickEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldTickEvents.java
@@ -21,6 +21,14 @@ import org.quiltmc.qsl.base.api.event.ArrayEvent;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
 
+/**
+ * Events related to a ticking Minecraft server's worlds.
+ *
+ * <h2>A note of warning</h2>
+ *
+ * Callbacks registered to any of these events should ensure as little time as possible is spent executing, since the tick
+ * loop is a very hot code path.
+ */
 public final class ServerWorldTickEvents {
 	/**
 	 * An event indicating that a world will be ticked.

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldTickEvents.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/ServerWorldTickEvents.java
@@ -1,0 +1,64 @@
+package org.quiltmc.qsl.lifecycle.api.event;
+
+import org.quiltmc.qsl.base.api.event.ArrayEvent;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+@Environment(EnvType.CLIENT)
+public final class ServerWorldTickEvents {
+	/**
+	 * An event indicating that a world will be ticked.
+	 */
+	public static final ArrayEvent<Start> START = ArrayEvent.create(Start.class, callbacks -> (server, world) -> {
+		for (var callback : callbacks) {
+			callback.startWorldTick(server, world);
+		}
+	});
+
+	/**
+	 * An event indicating that a world has finished being ticked.
+	 */
+	public static final ArrayEvent<End> END = ArrayEvent.create(End.class, callbacks -> (server, world) -> {
+		for (var callback : callbacks) {
+			callback.endWorldTick(server, world);
+		}
+	});
+
+	private ServerWorldTickEvents() {}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #START}.
+	 * @see #START
+	 */
+	@FunctionalInterface
+	@Environment(EnvType.CLIENT)
+	public interface Start {
+		/**
+		 * Called before a world is ticked.
+		 *
+		 * @param server the server
+		 * @param world the world being ticked
+		 */
+		void startWorldTick(MinecraftServer server, ServerWorld world);
+	}
+
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #END}.
+	 * @see #END
+	 */
+	@FunctionalInterface
+	@Environment(EnvType.CLIENT)
+	public interface End {
+		/**
+		 * Called after a world is ticked.
+		 *
+		 * @param server the server
+		 * @param world the world that was ticked
+		 */
+		void endWorldTick(MinecraftServer server, ServerWorld world);
+	}
+}

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/package-info.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/package-info.java
@@ -1,8 +1,8 @@
 /**
  * Events to track the lifecycle of Minecraft.
  *
- * <p>The events in this package track the lifecycle of a Minecraft server. A Minecraft server operates using a tick loop,
- * so these events are executed as the tick loop runs.
+ * <p>The events in this package track the lifecycle of a logical Minecraft server. A Minecraft server operates using a
+ * tick loop and events are executed as the tick loop runs.
  *
  * <p>The events in {@link org.quiltmc.qsl.lifecycle.api.event.ServerLifecycleEvents} are executed during server initialization
  * or server shutdown.

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/package-info.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/api/event/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Events to track the lifecycle of Minecraft.
+ *
+ * <p>The events in this package track the lifecycle of a Minecraft server. A Minecraft server operates using a tick loop,
+ * so these events are executed as the tick loop runs.
+ *
+ * <p>The events in {@link org.quiltmc.qsl.lifecycle.api.event.ServerLifecycleEvents} are executed during server initialization
+ * or server shutdown.
+ *
+ * <p>The events in {@link org.quiltmc.qsl.lifecycle.api.event.ServerTickEvents} are executed as the tick loop is iterated.
+ *
+ * <p>The events in {@link org.quiltmc.qsl.lifecycle.api.event.ServerWorldLoadEvents} are executed as the worlds on a
+ * server are loaded or unloaded.
+ *
+ * @see org.quiltmc.qsl.lifecycle.api.event.ServerLifecycleEvents
+ * @see org.quiltmc.qsl.lifecycle.api.event.ServerTickEvents
+ * @see org.quiltmc.qsl.lifecycle.api.event.ServerWorldLoadEvents
+ */
+
+package org.quiltmc.qsl.lifecycle.api.event;

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/MinecraftServerMixin.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/MinecraftServerMixin.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.lifecycle.mixin;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import org.quiltmc.qsl.lifecycle.api.event.ServerLifecycleEvents;
+import org.quiltmc.qsl.lifecycle.api.event.ServerTickEvents;
+import org.quiltmc.qsl.lifecycle.api.event.ServerWorldLoadEvents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+
+@Mixin(MinecraftServer.class)
+abstract class MinecraftServerMixin {
+	@Inject(method = "runServer",
+		at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;setupServer()Z"))
+	private void serverStarting(CallbackInfo info) {
+		ServerLifecycleEvents.SERVER_STARTING.invoker().serverStarting((MinecraftServer) (Object) this);
+	}
+
+	@Inject(method = "runServer",
+		at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;setFavicon(Lnet/minecraft/server/ServerMetadata;)V",
+			shift = At.Shift.AFTER))
+	private void serverReady(CallbackInfo info) {
+		ServerLifecycleEvents.SERVER_READY.invoker().serverReady((MinecraftServer) (Object) this);
+	}
+
+	@Inject(method = "shutdown", at = @At("HEAD"))
+	private void serverStopping(CallbackInfo info) {
+		ServerLifecycleEvents.SERVER_STOPPING.invoker().serverStopping((MinecraftServer) (Object) this);
+	}
+
+	@Inject(method = "shutdown", at = @At("TAIL"))
+	private void serverExit(CallbackInfo info) {
+		ServerLifecycleEvents.SERVER_EXIT.invoker().serverExit((MinecraftServer) (Object) this);
+	}
+
+	// Ticking
+
+	@Inject(method = "tick",
+		at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;tickWorlds(Ljava/util/function/BooleanSupplier;)V"))
+	private void startServerTick(CallbackInfo info) {
+		ServerTickEvents.START_SERVER_TICK.invoker().startServerTick((MinecraftServer) (Object) this);
+	}
+
+	@Inject(method = "tick", at = @At("TAIL"))
+	private void endServerTick(CallbackInfo info) {
+		ServerTickEvents.END_SERVER_TICK.invoker().endServerTick((MinecraftServer) (Object) this);
+	}
+
+	// Loading/unloading worlds
+
+	// Yes an Inject could be used for this and it would work with no issues.
+	//
+	// The reason for a redirect here is the frankly ridiculous amount of local variables that would be captured to obtain
+	// the instance of the world being loaded. A redirect does this much more cleanly.
+	@Redirect(method = "createWorlds", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
+	private <K, V> V loadWorld(Map<K, V> worlds, K key, V world) {
+		final V result = worlds.put(key, world);
+		ServerWorldLoadEvents.LOAD_WORLD.invoker().loadWorld((MinecraftServer) (Object) this, (ServerWorld) world);
+
+		return result;
+	}
+
+	@Inject(method = "shutdown",
+		at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;close()V"), locals = LocalCapture.CAPTURE_FAILHARD)
+	private void unloadWorld(CallbackInfo info, Iterator<ServerWorld> iterator, ServerWorld world) {
+		ServerWorldLoadEvents.UNLOAD_WORLD.invoker().unloadWorld((MinecraftServer) (Object) this, world);
+	}
+}

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/MinecraftServerMixin.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/MinecraftServerMixin.java
@@ -37,24 +37,24 @@ abstract class MinecraftServerMixin {
 	@Inject(method = "runServer",
 		at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;setupServer()Z"))
 	private void serverStarting(CallbackInfo info) {
-		ServerLifecycleEvents.SERVER_STARTING.invoker().serverStarting((MinecraftServer) (Object) this);
+		ServerLifecycleEvents.STARTING.invoker().startingServer((MinecraftServer) (Object) this);
 	}
 
 	@Inject(method = "runServer",
 		at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;setFavicon(Lnet/minecraft/server/ServerMetadata;)V",
 			shift = At.Shift.AFTER))
 	private void serverReady(CallbackInfo info) {
-		ServerLifecycleEvents.SERVER_READY.invoker().serverReady((MinecraftServer) (Object) this);
+		ServerLifecycleEvents.READY.invoker().readyServer((MinecraftServer) (Object) this);
 	}
 
 	@Inject(method = "shutdown", at = @At("HEAD"))
 	private void serverStopping(CallbackInfo info) {
-		ServerLifecycleEvents.SERVER_STOPPING.invoker().serverStopping((MinecraftServer) (Object) this);
+		ServerLifecycleEvents.STOPPING.invoker().stoppingServer((MinecraftServer) (Object) this);
 	}
 
 	@Inject(method = "shutdown", at = @At("TAIL"))
 	private void serverExit(CallbackInfo info) {
-		ServerLifecycleEvents.SERVER_EXIT.invoker().serverExit((MinecraftServer) (Object) this);
+		ServerLifecycleEvents.STOPPED.invoker().exitServer((MinecraftServer) (Object) this);
 	}
 
 	// Ticking
@@ -62,12 +62,12 @@ abstract class MinecraftServerMixin {
 	@Inject(method = "tick",
 		at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;tickWorlds(Ljava/util/function/BooleanSupplier;)V"))
 	private void startServerTick(CallbackInfo info) {
-		ServerTickEvents.START_SERVER_TICK.invoker().startServerTick((MinecraftServer) (Object) this);
+		ServerTickEvents.START.invoker().startServerTick((MinecraftServer) (Object) this);
 	}
 
 	@Inject(method = "tick", at = @At("TAIL"))
 	private void endServerTick(CallbackInfo info) {
-		ServerTickEvents.END_SERVER_TICK.invoker().endServerTick((MinecraftServer) (Object) this);
+		ServerTickEvents.END.invoker().endServerTick((MinecraftServer) (Object) this);
 	}
 
 	// Loading/unloading worlds
@@ -79,7 +79,7 @@ abstract class MinecraftServerMixin {
 	@Redirect(method = "createWorlds", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
 	private <K, V> V loadWorld(Map<K, V> worlds, K key, V world) {
 		final V result = worlds.put(key, world);
-		ServerWorldLoadEvents.LOAD_WORLD.invoker().loadWorld((MinecraftServer) (Object) this, (ServerWorld) world);
+		ServerWorldLoadEvents.LOAD.invoker().loadWorld((MinecraftServer) (Object) this, (ServerWorld) world);
 
 		return result;
 	}
@@ -87,6 +87,6 @@ abstract class MinecraftServerMixin {
 	@Inject(method = "shutdown",
 		at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;close()V"), locals = LocalCapture.CAPTURE_FAILHARD)
 	private void unloadWorld(CallbackInfo info, Iterator<ServerWorld> iterator, ServerWorld world) {
-		ServerWorldLoadEvents.UNLOAD_WORLD.invoker().unloadWorld((MinecraftServer) (Object) this, world);
+		ServerWorldLoadEvents.UNLOAD.invoker().unloadWorld((MinecraftServer) (Object) this, world);
 	}
 }

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/ServerWorldMixin.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/ServerWorldMixin.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.lifecycle.mixin;
+
+import org.quiltmc.qsl.lifecycle.api.event.ServerTickEvents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+
+@Mixin(ServerWorld.class)
+abstract class ServerWorldMixin {
+	@Shadow
+	public abstract MinecraftServer getServer();
+
+	@Inject(method = "tick", at = @At("HEAD"))
+	private void startTick(CallbackInfo info) {
+		ServerTickEvents.START_WORLD_TICK.invoker().startWorldTick(this.getServer(), (ServerWorld) (Object) this);
+	}
+
+	@Inject(method = "tick", at = @At("TAIL"))
+	private void endServerTick(CallbackInfo info) {
+		ServerTickEvents.END_WORLD_TICK.invoker().endWorldTick(this.getServer(), (ServerWorld) (Object) this);
+	}
+}

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/ServerWorldMixin.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/ServerWorldMixin.java
@@ -16,7 +16,7 @@
 
 package org.quiltmc.qsl.lifecycle.mixin;
 
-import org.quiltmc.qsl.lifecycle.api.event.ServerTickEvents;
+import org.quiltmc.qsl.lifecycle.api.event.ServerWorldTickEvents;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -33,11 +33,11 @@ abstract class ServerWorldMixin {
 
 	@Inject(method = "tick", at = @At("HEAD"))
 	private void startTick(CallbackInfo info) {
-		ServerTickEvents.START_WORLD_TICK.invoker().startWorldTick(this.getServer(), (ServerWorld) (Object) this);
+		ServerWorldTickEvents.START.invoker().startWorldTick(this.getServer(), (ServerWorld) (Object) this);
 	}
 
 	@Inject(method = "tick", at = @At("TAIL"))
 	private void endServerTick(CallbackInfo info) {
-		ServerTickEvents.END_WORLD_TICK.invoker().endWorldTick(this.getServer(), (ServerWorld) (Object) this);
+		ServerWorldTickEvents.END.invoker().endWorldTick(this.getServer(), (ServerWorld) (Object) this);
 	}
 }

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/client/ClientWorldMixin.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/client/ClientWorldMixin.java
@@ -1,0 +1,34 @@
+package org.quiltmc.qsl.lifecycle.mixin.client;
+
+import org.quiltmc.qsl.lifecycle.api.client.event.ClientWorldTickEvents;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.world.ClientWorld;
+
+@Mixin(ClientWorld.class)
+abstract class ClientWorldMixin {
+	@Shadow
+	@Final
+	private MinecraftClient client;
+
+	// The only client ticking we really care for is the ticking related to (block)entities. So we inject inside of
+	// tickEntities.
+	//
+	// There is a `tick()` method on the client world, but it does so very little (only advancing the time).
+
+	@Inject(method = "tickEntities", at = @At("HEAD"))
+	private void startTick(CallbackInfo info) {
+		ClientWorldTickEvents.START.invoker().startWorldTick(this.client, (ClientWorld) (Object) this);
+	}
+
+	@Inject(method = "tickEntities", at = @At("TAIL"))
+	private void endTick(CallbackInfo info) {
+		ClientWorldTickEvents.END.invoker().endWorldTick(this.client, (ClientWorld) (Object) this);
+	}
+}

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/client/ClientWorldMixin.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/client/ClientWorldMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.lifecycle.mixin.client;
 
 import org.quiltmc.qsl.lifecycle.api.client.event.ClientWorldTickEvents;

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/client/MinecraftClientMixin.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/client/MinecraftClientMixin.java
@@ -1,0 +1,50 @@
+package org.quiltmc.qsl.lifecycle.mixin.client;
+
+import org.quiltmc.qsl.lifecycle.api.client.event.ClientLifecycleEvents;
+import org.quiltmc.qsl.lifecycle.api.client.event.ClientTickEvents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.MinecraftClient;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+@Environment(EnvType.CLIENT)
+@Mixin(MinecraftClient.class)
+abstract class MinecraftClientMixin {
+	@Inject(method = "run",
+		at = @At(value = "FIELD", target = "Lnet/minecraft/client/MinecraftClient;thread:Ljava/lang/Thread;", shift = At.Shift.AFTER))
+	private void clientReady(CallbackInfo info) {
+		ClientLifecycleEvents.READY.invoker().readyClient((MinecraftClient) (Object) this);
+	}
+
+	@Inject(method = "stop",
+		at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;info(Ljava/lang/String;)V", shift = At.Shift.AFTER))
+	private void clientStopping(CallbackInfo info) {
+		ClientLifecycleEvents.STOPPING.invoker().stoppingClient((MinecraftClient) (Object) this);
+	}
+
+	@Inject(method = "stop",
+		at = {
+			@At(value = "INVOKE", target = "Ljava/lang/System;exit(I)V"), // Graceful JVM Exit
+			@At(value = "TAIL") // Final instruction
+		})
+	private void clientExit(CallbackInfo info) {
+		ClientLifecycleEvents.STOPPED.invoker().stoppedClient((MinecraftClient) (Object) this);
+	}
+
+	// Ticking
+
+	@Inject(at = @At("HEAD"), method = "tick")
+	private void startTick(CallbackInfo info) {
+		ClientTickEvents.START.invoker().startClientTick((MinecraftClient) (Object) this);
+	}
+
+	@Inject(at = @At("RETURN"), method = "tick")
+	private void endTick(CallbackInfo info) {
+		ClientTickEvents.END.invoker().endClientTick((MinecraftClient) (Object) this);
+	}
+}

--- a/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/client/MinecraftClientMixin.java
+++ b/library/core/lifecycle-events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/client/MinecraftClientMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.lifecycle.mixin.client;
 
 import org.quiltmc.qsl.lifecycle.api.client.event.ClientLifecycleEvents;

--- a/library/core/lifecycle-events/src/main/resources/fabric.mod.json
+++ b/library/core/lifecycle-events/src/main/resources/fabric.mod.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "id": "quilt_lifecycle_events",
+  "name": "Quilt Lifecycle events",
+  "version": "${version}",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "icon": "assets/quilt_lifecycle_events/icon.png",
+  "contact": {
+    "homepage": "https://quiltmc.org",
+    "issues": "https://github.com/QuiltMC/quilt-standard-libraries/issues",
+    "sources": "https://github.com/QuiltMC/quilt-standard-libraries"
+  },
+  "authors": [
+    "QuiltMC"
+  ],
+  "depends": {
+    "quilt_loader": ">=0.13.1-rc.10"
+  },
+  "description": "Events to track the lifecycle of Minecraft",
+  "mixins": [
+    "quilt_lifecycle_events.mixins.json"
+  ]
+}

--- a/library/core/lifecycle-events/src/main/resources/quilt_lifecycle_events.mixins.json
+++ b/library/core/lifecycle-events/src/main/resources/quilt_lifecycle_events.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "package": "org.quiltmc.qsl.lifecycle.mixin",
+  "compatibilityLevel": "JAVA_16",
+  "mixins": [
+    "MinecraftServerMixin",
+    "ServerWorldMixin"
+  ],
+  "client": [],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/library/core/lifecycle-events/src/main/resources/quilt_lifecycle_events.mixins.json
+++ b/library/core/lifecycle-events/src/main/resources/quilt_lifecycle_events.mixins.json
@@ -6,7 +6,10 @@
     "MinecraftServerMixin",
     "ServerWorldMixin"
   ],
-  "client": [],
+  "client": [
+    "client.ClientWorldMixin",
+    "client.MinecraftClientMixin"
+  ],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
This adds the lifecycle events module to the core library. These events are widely useful for tracking the game through client startup to shutdown and the same with the logical server.

This is not complete at the moment, I've only implemented the server lifecycle so far, I will do the client side shortly. Also some more detailed documentation should be written up. 
