### PR TITLE
Crash report info API

### DIFF
--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
@@ -1,0 +1,30 @@
+package org.quiltmc.qsl.crash.api;
+
+import net.minecraft.util.crash.CrashReportSection;
+import net.minecraft.world.World;
+import org.quiltmc.qsl.base.api.event.ArrayEvent;
+
+public final class CrashReportEvents {
+	public static final ArrayEvent<SystemDetails> SYSTEM_DETAILS = ArrayEvent.create(SystemDetails.class, callbacks -> details -> {
+		for (var callback : callbacks) {
+			callback.addDetails(details);
+		}
+	});
+
+	public static final ArrayEvent<WorldDetails> WORLD_DETAILS = ArrayEvent.create(WorldDetails.class, callbacks -> (world, details) -> {
+		for (var callback : callbacks) {
+			callback.addDetails(world, details);
+		}
+	});
+
+
+	@FunctionalInterface
+	public interface SystemDetails {
+		void addDetails(net.minecraft.util.SystemDetails details);
+	}
+
+	@FunctionalInterface
+	public interface WorldDetails {
+		void addDetails(World world, CrashReportSection section);
+	}
+}

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
@@ -11,69 +11,137 @@ import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 import org.quiltmc.qsl.base.api.event.ArrayEvent;
 
+import java.nio.file.Path;
+
+/**
+ * Events which allow the manipulation of crash reports.
+ *
+ * <p>Crash reports are created on the client and the server during a crash, and are also produced on the server every
+ * tick if debug/performance recording is enabled. ({@link net.minecraft.server.world.ServerWorld#dump(Path)})</p>
+ */
 public final class CrashReportEvents {
+	/**
+	 * An event for adding information to the "System Details" section of the crash report.
+	 *
+	 * <p>This section is added to all crashes.
+	 */
 	public static final ArrayEvent<SystemDetails> SYSTEM_DETAILS = ArrayEvent.create(SystemDetails.class, callbacks -> details -> {
 		for (var callback : callbacks) {
 			callback.addDetails(details);
 		}
 	});
 
+	/**
+	 * An event for adding information to the "Affected level" section of the crash report.
+	 *
+	 * <p>This section is added to all crashes caused by something in-world.
+	 */
 	public static final ArrayEvent<WorldDetails> WORLD_DETAILS = ArrayEvent.create(WorldDetails.class, callbacks -> (world, section) -> {
 		for (var callback : callbacks) {
 			callback.addDetails(world, section);
 		}
 	});
 
+	/**
+	 * An event for adding information about a block to a crash report.
+	 *
+	 * <p>This is used as its own section if a block tick causes the crash, or is appended to a block entity section if
+	 * a block entity causes a crash.
+	 */
 	public static final ArrayEvent<BlockDetails> BLOCK_DETAILS = ArrayEvent.create(BlockDetails.class, callbacks -> (world, pos, state, section) -> {
 		for (var callback : callbacks) {
 			callback.addDetails(world, pos, state, section);
 		}
 	});
 
+	/**
+	 * An event for adding information about an entity to a crash report.
+	 *
+	 * <p>This section is added to crashes caused by ticking or rendering an entity.
+	 */
 	public static final ArrayEvent<EntityDetails> ENTITY_DETAILS = ArrayEvent.create(EntityDetails.class, callbacks -> (entity, section) -> {
 		for (var callback : callbacks) {
 			callback.addDetails(entity, section);
 		}
 	});
 
+	/**
+	 * An event for adding information about a block entity to a crash report.
+	 *
+	 * <p>This section is added to crashes caused by ticking or rendering a block entity.
+	 */
 	public static final ArrayEvent<BlockEntityDetails> BLOCKENTITY_DETAILS = ArrayEvent.create(BlockEntityDetails.class, callbacks -> (blockentity, section) -> {
 		for (var callback : callbacks) {
 			callback.addDetails(blockentity, section);
 		}
 	});
 
+	/**
+	 * An event for modifying a crash report before it is {@link CrashReport#addStackTrace(StringBuilder) stringified}.
+	 *
+	 * <p>This can be used for adding new sections, with {@link CrashReport#addElement(String)}.
+	 */
 	public static final ArrayEvent<CrashReportCreation> CRASH_REPORT_CREATION = ArrayEvent.create(CrashReportCreation.class, callbacks -> report -> {
 		for (var callback : callbacks) {
 			callback.onCreate(report);
 		}
 	});
 
-
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #SYSTEM_DETAILS}.
+	 *
+	 * @see #SYSTEM_DETAILS
+	 */
 	@FunctionalInterface
 	public interface SystemDetails {
 		void addDetails(net.minecraft.util.SystemDetails details);
 	}
 
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #SYSTEM_DETAILS}.
+	 *
+	 * @see #SYSTEM_DETAILS
+	 */
 	@FunctionalInterface
 	public interface WorldDetails {
 		void addDetails(World world, CrashReportSection section);
 	}
 
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #BLOCK_DETAILS}.
+	 *
+	 * @see #BLOCK_DETAILS
+	 */
 	@FunctionalInterface
 	public interface BlockDetails {
 		void addDetails(HeightLimitView world, BlockPos pos, @Nullable BlockState state, CrashReportSection section);
 	}
 
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #ENTITY_DETAILS}.
+	 *
+	 * @see #ENTITY_DETAILS
+	 */
 	@FunctionalInterface
 	public interface EntityDetails {
 		void addDetails(Entity entity, CrashReportSection section);
 	}
 
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #BLOCKENTITY_DETAILS}.
+	 *
+	 * @see #BLOCKENTITY_DETAILS
+	 */
 	@FunctionalInterface
 	public interface BlockEntityDetails {
 		void addDetails(BlockEntity entity, CrashReportSection section);
 	}
 
+	/**
+	 * Functional interface to be implemented on callbacks for {@link #CRASH_REPORT_CREATION}.
+	 *
+	 * @see #CRASH_REPORT_CREATION
+	 */
 	@FunctionalInterface
 	public interface CrashReportCreation {
 		void onCreate(CrashReport report);

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
@@ -42,7 +42,7 @@ public final class CrashReportEvents {
 		}
 	});
 
-	public static final ArrayEvent<CrashReportCreation> CRASH_REPORT_CREATED = ArrayEvent.create(CrashReportCreation.class, callbacks -> report -> {
+	public static final ArrayEvent<CrashReportCreation> CRASH_REPORT_CREATION = ArrayEvent.create(CrashReportCreation.class, callbacks -> report -> {
 		for (var callback : callbacks) {
 			callback.onCreate(report);
 		}

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
@@ -1,8 +1,14 @@
 package org.quiltmc.qsl.crash.api;
 
+import net.minecraft.block.BlockState;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.entity.Entity;
 import net.minecraft.util.crash.CrashReport;
 import net.minecraft.util.crash.CrashReportSection;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.HeightLimitView;
 import net.minecraft.world.World;
+import org.jetbrains.annotations.Nullable;
 import org.quiltmc.qsl.base.api.event.ArrayEvent;
 
 public final class CrashReportEvents {
@@ -12,9 +18,27 @@ public final class CrashReportEvents {
 		}
 	});
 
-	public static final ArrayEvent<WorldDetails> WORLD_DETAILS = ArrayEvent.create(WorldDetails.class, callbacks -> (world, details) -> {
+	public static final ArrayEvent<WorldDetails> WORLD_DETAILS = ArrayEvent.create(WorldDetails.class, callbacks -> (world, section) -> {
 		for (var callback : callbacks) {
-			callback.addDetails(world, details);
+			callback.addDetails(world, section);
+		}
+	});
+
+	public static final ArrayEvent<BlockDetails> BLOCK_DETAILS = ArrayEvent.create(BlockDetails.class, callbacks -> (world, pos, state, section) -> {
+		for (var callback : callbacks) {
+			callback.addDetails(world, pos, state, section);
+		}
+	});
+
+	public static final ArrayEvent<EntityDetails> ENTITY_DETAILS = ArrayEvent.create(EntityDetails.class, callbacks -> (entity, section) -> {
+		for (var callback : callbacks) {
+			callback.addDetails(entity, section);
+		}
+	});
+
+	public static final ArrayEvent<BlockEntityDetails> BLOCKENTITY_DETAILS = ArrayEvent.create(BlockEntityDetails.class, callbacks -> (blockentity, section) -> {
+		for (var callback : callbacks) {
+			callback.addDetails(blockentity, section);
 		}
 	});
 
@@ -33,6 +57,21 @@ public final class CrashReportEvents {
 	@FunctionalInterface
 	public interface WorldDetails {
 		void addDetails(World world, CrashReportSection section);
+	}
+
+	@FunctionalInterface
+	public interface BlockDetails {
+		void addDetails(HeightLimitView world, BlockPos pos, @Nullable BlockState state, CrashReportSection section);
+	}
+
+	@FunctionalInterface
+	public interface EntityDetails {
+		void addDetails(Entity entity, CrashReportSection section);
+	}
+
+	@FunctionalInterface
+	public interface BlockEntityDetails {
+		void addDetails(BlockEntity entity, CrashReportSection section);
 	}
 
 	@FunctionalInterface

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
@@ -1,5 +1,6 @@
 package org.quiltmc.qsl.crash.api;
 
+import net.minecraft.util.crash.CrashReport;
 import net.minecraft.util.crash.CrashReportSection;
 import net.minecraft.world.World;
 import org.quiltmc.qsl.base.api.event.ArrayEvent;
@@ -17,6 +18,12 @@ public final class CrashReportEvents {
 		}
 	});
 
+	public static final ArrayEvent<CrashReportCreation> CRASH_REPORT_CREATED = ArrayEvent.create(CrashReportCreation.class, callbacks -> report -> {
+		for (var callback : callbacks) {
+			callback.onCreate(report);
+		}
+	});
+
 
 	@FunctionalInterface
 	public interface SystemDetails {
@@ -26,5 +33,10 @@ public final class CrashReportEvents {
 	@FunctionalInterface
 	public interface WorldDetails {
 		void addDetails(World world, CrashReportSection section);
+	}
+
+	@FunctionalInterface
+	public interface CrashReportCreation {
+		void onCreate(CrashReport report);
 	}
 }

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
@@ -114,9 +114,9 @@ public final class CrashReportEvents {
 	}
 
 	/**
-	 * Functional interface to be implemented on callbacks for {@link #SYSTEM_DETAILS}.
+	 * Functional interface to be implemented on callbacks for {@link #WORLD_DETAILS}.
 	 *
-	 * @see #SYSTEM_DETAILS
+	 * @see #WORLD_DETAILS
 	 */
 	@FunctionalInterface
 	public interface WorldDetails {

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/api/CrashReportEvents.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.crash.api;
 
 import net.minecraft.block.BlockState;

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/impl/CrashInfoImpl.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/impl/CrashInfoImpl.java
@@ -3,8 +3,10 @@ package org.quiltmc.qsl.crash.impl;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
+import org.jetbrains.annotations.ApiStatus;
 import org.quiltmc.qsl.crash.api.CrashReportEvents;
 
+@ApiStatus.Internal
 public final class CrashInfoImpl implements ModInitializer {
 	@Override
 	public void onInitialize() {

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/impl/CrashInfoImpl.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/impl/CrashInfoImpl.java
@@ -1,0 +1,27 @@
+package org.quiltmc.qsl.crash.impl;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import org.quiltmc.qsl.crash.api.CrashReportEvents;
+
+public final class CrashInfoImpl implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		CrashReportEvents.SYSTEM_DETAILS.register(details -> details.addSection("Quilt Mods", () -> {
+			StringBuilder builder = new StringBuilder();
+
+			for (ModContainer mod : FabricLoader.getInstance().getAllMods()) {
+				var metadata = mod.getMetadata();
+
+				builder.append("\n\t\t%s: %s %s".formatted(
+						metadata.getId(),
+						metadata.getName(),
+						metadata.getVersion().getFriendlyString())
+				);
+			}
+
+			return builder.toString();
+		}));
+	}
+}

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/BlockEntityMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/BlockEntityMixin.java
@@ -1,0 +1,18 @@
+package org.quiltmc.qsl.crash.mixin;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.util.crash.CrashReportSection;
+import org.quiltmc.qsl.crash.api.CrashReportEvents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(BlockEntity.class)
+public abstract class BlockEntityMixin {
+	@Inject(method = "populateCrashReport", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/util/crash/CrashReportSection;add(Ljava/lang/String;Lnet/minecraft/util/crash/CrashCallable;)Lnet/minecraft/util/crash/CrashReportSection;"), locals = LocalCapture.CAPTURE_FAILHARD)
+	void addCrashReportDetails(CrashReportSection section, CallbackInfo ci) {
+		CrashReportEvents.BLOCKENTITY_DETAILS.invoker().addDetails((BlockEntity) (Object) this, section);
+	}
+}

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/BlockEntityMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/BlockEntityMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.crash.mixin;
 
 import net.minecraft.block.entity.BlockEntity;

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/BlockEntityMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/BlockEntityMixin.java
@@ -23,11 +23,10 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(BlockEntity.class)
 public abstract class BlockEntityMixin {
-	@Inject(method = "populateCrashReport", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/util/crash/CrashReportSection;add(Ljava/lang/String;Lnet/minecraft/util/crash/CrashCallable;)Lnet/minecraft/util/crash/CrashReportSection;"), locals = LocalCapture.CAPTURE_FAILHARD)
+	@Inject(method = "populateCrashReport", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/util/crash/CrashReportSection;add(Ljava/lang/String;Lnet/minecraft/util/crash/CrashCallable;)Lnet/minecraft/util/crash/CrashReportSection;"))
 	void addCrashReportDetails(CrashReportSection section, CallbackInfo ci) {
 		CrashReportEvents.BLOCKENTITY_DETAILS.invoker().addDetails((BlockEntity) (Object) this, section);
 	}

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/CrashReportMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/CrashReportMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.crash.mixin;
 
 import net.minecraft.util.crash.CrashReport;

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/CrashReportMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/CrashReportMixin.java
@@ -11,6 +11,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class CrashReportMixin {
 	@Inject(method = "addStackTrace", at = @At(value = "INVOKE", target = "Ljava/util/List;iterator()Ljava/util/Iterator;"))
 	void onCrashReportCreated(StringBuilder crashReportBuilder, CallbackInfo ci) {
-		CrashReportEvents.CRASH_REPORT_CREATED.invoker().onCreate((CrashReport) (Object) this);
+		CrashReportEvents.CRASH_REPORT_CREATION.invoker().onCreate((CrashReport) (Object) this);
 	}
 }

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/CrashReportMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/CrashReportMixin.java
@@ -1,0 +1,16 @@
+package org.quiltmc.qsl.crash.mixin;
+
+import net.minecraft.util.crash.CrashReport;
+import org.quiltmc.qsl.crash.api.CrashReportEvents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(CrashReport.class)
+public abstract class CrashReportMixin {
+	@Inject(method = "addStackTrace", at = @At(value = "INVOKE", target = "Ljava/util/List;iterator()Ljava/util/Iterator;"))
+	void onCrashReportCreated(StringBuilder crashReportBuilder, CallbackInfo ci) {
+		CrashReportEvents.CRASH_REPORT_CREATED.invoker().onCreate((CrashReport) (Object) this);
+	}
+}

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/CrashReportSectionMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/CrashReportSectionMixin.java
@@ -1,0 +1,20 @@
+package org.quiltmc.qsl.crash.mixin;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.util.crash.CrashReportSection;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.HeightLimitView;
+import org.quiltmc.qsl.crash.api.CrashReportEvents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(CrashReportSection.class)
+public abstract class CrashReportSectionMixin {
+	@Inject(method = "addBlockInfo", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
+	private static void addCrashReportDetails(CrashReportSection element, HeightLimitView world, BlockPos pos, BlockState state, CallbackInfo ci) {
+		CrashReportEvents.BLOCK_DETAILS.invoker().addDetails(world, pos, state, element);
+	}
+}

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/CrashReportSectionMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/CrashReportSectionMixin.java
@@ -29,7 +29,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(CrashReportSection.class)
 public abstract class CrashReportSectionMixin {
-	@Inject(method = "addBlockInfo", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
+	@Inject(method = "addBlockInfo", at = @At("TAIL"))
 	private static void addCrashReportDetails(CrashReportSection element, HeightLimitView world, BlockPos pos, BlockState state, CallbackInfo ci) {
 		CrashReportEvents.BLOCK_DETAILS.invoker().addDetails(world, pos, state, element);
 	}

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/CrashReportSectionMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/CrashReportSectionMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.crash.mixin;
 
 import net.minecraft.block.BlockState;

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/EntityMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/EntityMixin.java
@@ -1,0 +1,18 @@
+package org.quiltmc.qsl.crash.mixin;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.crash.CrashReportSection;
+import org.quiltmc.qsl.crash.api.CrashReportEvents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(Entity.class)
+public abstract class EntityMixin {
+	@Inject(method = "populateCrashReport", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
+	void addCrashReportDetails(CrashReportSection section, CallbackInfo ci) {
+		CrashReportEvents.ENTITY_DETAILS.invoker().addDetails((Entity) (Object) this, section);
+	}
+}

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/EntityMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/EntityMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.crash.mixin;
 
 import net.minecraft.entity.Entity;

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/EntityMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/EntityMixin.java
@@ -23,11 +23,10 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(Entity.class)
 public abstract class EntityMixin {
-	@Inject(method = "populateCrashReport", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
+	@Inject(method = "populateCrashReport", at = @At("TAIL"))
 	void addCrashReportDetails(CrashReportSection section, CallbackInfo ci) {
 		CrashReportEvents.ENTITY_DETAILS.invoker().addDetails((Entity) (Object) this, section);
 	}

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/SystemDetailsMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/SystemDetailsMixin.java
@@ -16,8 +16,6 @@
 
 package org.quiltmc.qsl.crash.mixin;
 
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.util.SystemDetails;
 import org.quiltmc.qsl.crash.api.CrashReportEvents;
 import org.spongepowered.asm.mixin.Mixin;
@@ -38,22 +36,6 @@ abstract class SystemDetailsMixin {
 	 */
 	@Inject(method = "<init>", at = @At("TAIL"))
 	private void addQuiltMods(CallbackInfo info) {
-		this.addSection("Quilt Mods", () -> {
-			StringBuilder builder = new StringBuilder();
-
-			for (ModContainer mod : FabricLoader.getInstance().getAllMods()) {
-				var metadata = mod.getMetadata();
-
-				builder.append("\n\t\t%s: %s %s".formatted(
-						metadata.getId(),
-						metadata.getName(),
-						metadata.getVersion().getFriendlyString())
-				);
-			}
-
-			return builder.toString();
-		});
-
 		CrashReportEvents.SYSTEM_DETAILS.invoker().addDetails((SystemDetails) (Object) this);
 	}
 }

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/SystemDetailsMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/SystemDetailsMixin.java
@@ -16,18 +16,17 @@
 
 package org.quiltmc.qsl.crash.mixin;
 
-import java.util.function.Supplier;
-
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.minecraft.util.SystemDetails;
+import org.quiltmc.qsl.crash.api.CrashReportEvents;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.util.SystemDetails;
-
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.ModContainer;
+import java.util.function.Supplier;
 
 @Mixin(SystemDetails.class)
 abstract class SystemDetailsMixin {
@@ -55,6 +54,6 @@ abstract class SystemDetailsMixin {
 			return builder.toString();
 		});
 
-		// If we wish to add any additional sections, this is a great place to do so.
+		CrashReportEvents.SYSTEM_DETAILS.invoker().addDetails((SystemDetails) (Object) this);
 	}
 }

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/WorldMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/WorldMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.crash.mixin;
 
 import net.minecraft.util.crash.CrashReport;

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/WorldMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/WorldMixin.java
@@ -11,8 +11,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(World.class)
-public class WorldMixin {
-	@Inject(method = "addDetailsToCrashReport", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILSOFT)
+public abstract class WorldMixin {
+	@Inject(method = "addDetailsToCrashReport", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
 	void quilt$addCrashReportDetails(CrashReport report, CallbackInfoReturnable<CrashReportSection> cir, CrashReportSection crashReportSection) {
 		CrashReportEvents.WORLD_DETAILS.invoker().addDetails((World) (Object) this, crashReportSection);
 	}

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/WorldMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/WorldMixin.java
@@ -1,0 +1,19 @@
+package org.quiltmc.qsl.crash.mixin;
+
+import net.minecraft.util.crash.CrashReport;
+import net.minecraft.util.crash.CrashReportSection;
+import net.minecraft.world.World;
+import org.quiltmc.qsl.crash.api.CrashReportEvents;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(World.class)
+public class WorldMixin {
+	@Inject(method = "addDetailsToCrashReport", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILSOFT)
+	void quilt$addCrashReportDetails(CrashReport report, CallbackInfoReturnable<CrashReportSection> cir, CrashReportSection crashReportSection) {
+		CrashReportEvents.WORLD_DETAILS.invoker().addDetails((World) (Object) this, crashReportSection);
+	}
+}

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/WorldMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/WorldMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 @Mixin(World.class)
 public abstract class WorldMixin {
 	@Inject(method = "addDetailsToCrashReport", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
-	void quilt$addCrashReportDetails(CrashReport report, CallbackInfoReturnable<CrashReportSection> cir, CrashReportSection crashReportSection) {
+	void addCrashReportDetails(CrashReport report, CallbackInfoReturnable<CrashReportSection> cir, CrashReportSection crashReportSection) {
 		CrashReportEvents.WORLD_DETAILS.invoker().addDetails((World) (Object) this, crashReportSection);
 	}
 }

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/WorldMixin.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/mixin/WorldMixin.java
@@ -28,8 +28,8 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(World.class)
 public abstract class WorldMixin {
-	@Inject(method = "addDetailsToCrashReport", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
-	void addCrashReportDetails(CrashReport report, CallbackInfoReturnable<CrashReportSection> cir, CrashReportSection crashReportSection) {
-		CrashReportEvents.WORLD_DETAILS.invoker().addDetails((World) (Object) this, crashReportSection);
+	@Inject(method = "addDetailsToCrashReport", at = @At("TAIL"))
+	void addCrashReportDetails(CrashReport report, CallbackInfoReturnable<CrashReportSection> cir) {
+		CrashReportEvents.WORLD_DETAILS.invoker().addDetails((World) (Object) this, cir.getReturnValue());
 	}
 }

--- a/library/core/crash_info/src/main/resources/fabric.mod.json
+++ b/library/core/crash_info/src/main/resources/fabric.mod.json
@@ -17,7 +17,7 @@
   "depends": {
     "quilt_loader": ">=0.13.1-rc.10"
   },
-  "description": "Includes information about the Quilt environment in crash reports",
+  "description": "Adds information about the Quilt environment in crash reports, and provides an API for other mods to add their own information.",
   "mixins": [
     "quilt_crash_info.mixins.json"
   ]

--- a/library/core/crash_info/src/main/resources/fabric.mod.json
+++ b/library/core/crash_info/src/main/resources/fabric.mod.json
@@ -14,6 +14,11 @@
   "authors": [
     "QuiltMC"
   ],
+  "entrypoints": {
+    "main": [
+      "org.quiltmc.qsl.crash.impl.CrashInfoImpl"
+    ]
+  },
   "depends": {
     "quilt_loader": ">=0.13.1-rc.10"
   },

--- a/library/core/crash_info/src/main/resources/quilt_crash_info.mixins.json
+++ b/library/core/crash_info/src/main/resources/quilt_crash_info.mixins.json
@@ -3,7 +3,8 @@
   "package": "org.quiltmc.qsl.crash.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
-    "SystemDetailsMixin"
+    "SystemDetailsMixin",
+    "WorldMixin"
   ],
   "client": [],
   "injectors": {

--- a/library/core/crash_info/src/main/resources/quilt_crash_info.mixins.json
+++ b/library/core/crash_info/src/main/resources/quilt_crash_info.mixins.json
@@ -3,7 +3,10 @@
   "package": "org.quiltmc.qsl.crash.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
+    "BlockEntityMixin",
     "CrashReportMixin",
+    "CrashReportSectionMixin",
+    "EntityMixin",
     "SystemDetailsMixin",
     "WorldMixin"
   ],

--- a/library/core/crash_info/src/main/resources/quilt_crash_info.mixins.json
+++ b/library/core/crash_info/src/main/resources/quilt_crash_info.mixins.json
@@ -3,6 +3,7 @@
   "package": "org.quiltmc.qsl.crash.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
+    "CrashReportMixin",
     "SystemDetailsMixin",
     "WorldMixin"
   ],

--- a/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/CrashReportApiTestMod.java
+++ b/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/CrashReportApiTestMod.java
@@ -23,6 +23,13 @@ import org.quiltmc.qsl.crash.api.CrashReportEvents;
 
 import java.util.Random;
 
+/**
+ * Test mod for Crash Report Events.
+ *
+ * <p>To cause an entity crash, summon an end crystal atop a block of diamond.
+ *
+ * <p>To cause a BE crash, place a furnace atop a block of diamond.
+ */
 public class CrashReportApiTestMod implements ModInitializer {
 	@Override
 	public void onInitialize() {

--- a/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/CrashReportApiTestMod.java
+++ b/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/CrashReportApiTestMod.java
@@ -21,6 +21,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.registry.Registry;
 import org.quiltmc.qsl.crash.api.CrashReportEvents;
 
+import java.util.Random;
+
 public class CrashReportApiTestMod implements ModInitializer {
 	@Override
 	public void onInitialize() {
@@ -30,6 +32,12 @@ public class CrashReportApiTestMod implements ModInitializer {
 
 		CrashReportEvents.WORLD_DETAILS.register((world, section) -> {
 			section.add("Biome at 0,0,0", world.getRegistryManager().get(Registry.BIOME_KEY).getId(world.getBiome(BlockPos.ORIGIN)));
+		});
+
+		CrashReportEvents.CRASH_REPORT_CREATED.register(report -> {
+			report.addElement("Test Section")
+					.add("A thing?", "A thing.")
+					.add("A random number", new Random().nextInt());
 		});
 	}
 }

--- a/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/CrashReportApiTestMod.java
+++ b/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/CrashReportApiTestMod.java
@@ -34,6 +34,18 @@ public class CrashReportApiTestMod implements ModInitializer {
 			section.add("Biome at 0,0,0", world.getRegistryManager().get(Registry.BIOME_KEY).getId(world.getBiome(BlockPos.ORIGIN)));
 		});
 
+		CrashReportEvents.BLOCK_DETAILS.register((world, pos, state, section) -> {
+			section.add("World height", world.getHeight());
+		});
+
+		CrashReportEvents.BLOCKENTITY_DETAILS.register((entity, section) -> {
+			section.add("Is removed", entity.isRemoved());
+		});
+
+		CrashReportEvents.ENTITY_DETAILS.register((entity, section) -> {
+			section.add("Entity age", entity.age);
+		});
+
 		CrashReportEvents.CRASH_REPORT_CREATED.register(report -> {
 			report.addElement("Test Section")
 					.add("A thing?", "A thing.")

--- a/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/CrashReportApiTestMod.java
+++ b/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/CrashReportApiTestMod.java
@@ -46,7 +46,7 @@ public class CrashReportApiTestMod implements ModInitializer {
 			section.add("Entity age", entity.age);
 		});
 
-		CrashReportEvents.CRASH_REPORT_CREATED.register(report -> {
+		CrashReportEvents.CRASH_REPORT_CREATION.register(report -> {
 			report.addElement("Test Section")
 					.add("A thing?", "A thing.")
 					.add("A random number", new Random().nextInt());

--- a/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/CrashReportApiTestMod.java
+++ b/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/CrashReportApiTestMod.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.crash.test;
+
+import net.fabricmc.api.ModInitializer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.Registry;
+import org.quiltmc.qsl.crash.api.CrashReportEvents;
+
+public class CrashReportApiTestMod implements ModInitializer {
+	@Override
+	public void onInitialize() {
+		CrashReportEvents.SYSTEM_DETAILS.register(details -> {
+			details.addSection("Value of Pi", Double.toString(Math.PI));
+		});
+
+		CrashReportEvents.WORLD_DETAILS.register((world, section) -> {
+			section.add("Biome at 0,0,0", world.getRegistryManager().get(Registry.BIOME_KEY).getId(world.getBiome(BlockPos.ORIGIN)));
+		});
+	}
+}

--- a/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/mixin/AbstractFurnaceBlockEntityMixin.java
+++ b/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/mixin/AbstractFurnaceBlockEntityMixin.java
@@ -1,0 +1,22 @@
+package org.quiltmc.qsl.crash.test.mixin;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(AbstractFurnaceBlockEntity.class)
+public abstract class AbstractFurnaceBlockEntityMixin {
+	@Inject(method = "tick", at=@At("HEAD"))
+	private static void crashOnTick(World world, BlockPos pos, BlockState state, AbstractFurnaceBlockEntity blockEntity, CallbackInfo ci) {
+		if (world.getBlockState(pos.down()).getBlock() == Blocks.DIAMOND_BLOCK) {
+			world.removeBlock(pos, false);
+			throw new RuntimeException("Crash Test!");
+		}
+	}
+}

--- a/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/mixin/AbstractFurnaceBlockEntityMixin.java
+++ b/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/mixin/AbstractFurnaceBlockEntityMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.crash.test.mixin;
 
 import net.minecraft.block.BlockState;

--- a/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/mixin/EndCrystalEntityMixin.java
+++ b/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/mixin/EndCrystalEntityMixin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.crash.test.mixin;
 
 import net.minecraft.block.Blocks;

--- a/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/mixin/EndCrystalEntityMixin.java
+++ b/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/mixin/EndCrystalEntityMixin.java
@@ -35,7 +35,7 @@ public abstract class EndCrystalEntityMixin extends Entity {
 	@Inject(method = "tick", at=@At("HEAD"))
 	void crashOnTick(CallbackInfo ci) {
 		if (world.getBlockState(getBlockPos().down()).getBlock() == Blocks.DIAMOND_BLOCK) {
-			kill();
+			this.kill();
 			throw new RuntimeException("Crash Test!");
 		}
 	}

--- a/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/mixin/EndCrystalEntityMixin.java
+++ b/library/core/crash_info/src/testmod/java/org/quiltmc/qsl/crash/test/mixin/EndCrystalEntityMixin.java
@@ -1,0 +1,26 @@
+package org.quiltmc.qsl.crash.test.mixin;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.decoration.EndCrystalEntity;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EndCrystalEntity.class)
+public abstract class EndCrystalEntityMixin extends Entity {
+	public EndCrystalEntityMixin(EntityType<?> type, World world) {
+		super(type, world);
+	}
+
+	@Inject(method = "tick", at=@At("HEAD"))
+	void crashOnTick(CallbackInfo ci) {
+		if (world.getBlockState(getBlockPos().down()).getBlock() == Blocks.DIAMOND_BLOCK) {
+			kill();
+			throw new RuntimeException("Crash Test!");
+		}
+	}
+}

--- a/library/core/crash_info/src/testmod/resources/fabric.mod.json
+++ b/library/core/crash_info/src/testmod/resources/fabric.mod.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "id": "quilt_crash_info_testmod",
+  "name": "Quilt Crash Info Test Mod",
+  "version": "1.0.0",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "depends": {
+    "quilt_crash_info": "*"
+  },
+  "entrypoints": {
+    "main": [
+      "org.quiltmc.qsl.crash.test.CrashReportApiTestMod"
+    ]
+  }
+}

--- a/library/core/crash_info/src/testmod/resources/fabric.mod.json
+++ b/library/core/crash_info/src/testmod/resources/fabric.mod.json
@@ -12,5 +12,8 @@
     "main": [
       "org.quiltmc.qsl.crash.test.CrashReportApiTestMod"
     ]
-  }
+  },
+  "mixins": [
+    "quilt_crash_info_testmod.mixins.json"
+  ]
 }

--- a/library/core/crash_info/src/testmod/resources/quilt_crash_info_testmod.mixins.json
+++ b/library/core/crash_info/src/testmod/resources/quilt_crash_info_testmod.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "package": "org.quiltmc.qsl.crash.test.mixin",
+  "compatibilityLevel": "JAVA_16",
+  "mixins": [
+    "AbstractFurnaceBlockEntityMixin",
+    "EndCrystalEntityMixin"
+  ],
+  "client": [],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
This PR adds six events for adding details to crash reports:
 - `SystemDetails` allows for adding details with no level-context, such as native library versions.
 - `WorldDetails` allows for adding details with a level-context, such as data attached to the player or level.
 - `BlockDetails` allows for adding details in the context of a block.
 - `EntityDetails` allows for adding details about a specific entity.
 - `BlockEntityDetails` allows for adding details about a specific blockentity.
 - `CrashReportCreation` allows for adding new sections to a crash report.

Closes #23.