### PR TITLE
Replace license header checker, and update license headers.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,37 +16,35 @@ the field should be named with the namespace first, then the name of the injecte
 
 ## Licensing
 
-Quilt Standard Libraries are licensed under [Apache 2.0][LICENSE], which means your contributions should not introduce code of incompatible licensing.
+QSL is licensed under [Apache 2.0][LICENSE], which means contributions should not introduce incompatibly licensed code.
 
 ### License Headers
 
-Every Java source file in QSL has a license header, it allows keeping track of creation date,
-and last modification for the copyright notice of each file individually.
+Every Java source file in QSL has a license header with a copyright notice that keeps track of its creation date and last modification date.
 
 Two gradle tasks are dedicated to them:
  - `:checkLicenses` will check the presence and validity of the license header in each Java source file;
- - `:applyLicenses` will automatically apply to Java source file the correct license header,
-    it can be used to append the header if it's missing, to update dates, and to update in the whole code base easily
-    every license headers if necessary.
+ - `:applyLicenses` will automatically apply the correct license header to every Java source file;
+    it can be used to add missing headers and update copyright dates across the whole code base.
 
-So, before committing, remember executing `:applyLicenses`!
+So, before committing, remember to run `:applyLicenses`!
 
 #### Derivative Work
 
-If your work isn't entirely original, then the default license header should not apply, here's what to do in different cases:
+If your work isn't entirely original, then the default license header should not apply. Here's what to do in different cases:
 
 ##### My work comes from Fabric API
 
 If your work comes from Fabric API, then you should put `/// FABRIC` at the beginning of your file,
 or in the case you're copying an entire file in it, you can just keep the same header without modification.
 
-Make sure to execute the `:applyLicenses` task as it will apply a special license header to Fabric API-derived files mentioning Fabric's copyright notice.
+Make sure to execute the `:applyLicenses` task as it will apply a special license header to Fabric API-derived files mentioning Fabric's copyright notice. **Files derived from Fabric must use this license header!**
 
 ##### My work comes from somewhere else
 
-If it's your own, then not much is needed to be done if you don't mind it being licensed under [Apache 2][LICENSE].
+If the original work is entirely your own, then nothing needs to be done as long as you don't mind it being licensed under [Apache 2][LICENSE].
 
-Otherwise, you should make sure that this work is compatible with the [Apache 2][LICENSE] license,
-and discuss with a QSL Team member whether the work should be included and how.
+Otherwise, you should make sure that this work is compatible with the [Apache 2][LICENSE] license
+and discuss with a QSL Team member whether the work can be included and how.
 
 [LICENSE]: ./LICENSE "Quilt Standard Libraries license file"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,40 @@ in other words it allows to separate the actual name of the variable and the nam
 
 In the case of a pseudo-local variable (a field used briefly to pass around a local variable of a method between 2 injections of said method),
 the field should be named with the namespace first, then the name of the injected method, and finally the name of the local (`quilt$injectedMethod$localName`).
+
+## Licensing
+
+Quilt Standard Libraries are licensed under [Apache 2.0][LICENSE], which means your contributions should not introduce code of incompatible licensing.
+
+### License Headers
+
+Every Java source file in QSL has a license header, it allows keeping track of creation date,
+and last modification for the copyright notice of each file individually.
+
+Two gradle tasks are dedicated to them:
+ - `:checkLicenses` will check the presence and validity of the license header in each Java source file;
+ - `:applyLicenses` will automatically apply to Java source file the correct license header,
+    it can be used to append the header if it's missing, to update dates, and to update in the whole code base easily
+    every license headers if necessary.
+
+So, before committing, remember executing `:applyLicenses`!
+
+#### Derivative Work
+
+If your work isn't entirely original, then the default license header should not apply, here's what to do in different cases:
+
+##### My work comes from Fabric API
+
+If your work comes from Fabric API, then you should put `/// FABRIC` at the beginning of your file,
+or in the case you're copying an entire file in it, you can just keep the same header without modification.
+
+Make sure to execute the `:applyLicenses` task as it will apply a special license header to Fabric API-derived files mentioning Fabric's copyright notice.
+
+##### My work comes from somewhere else
+
+If it's your own, then not much is needed to be done if you don't mind it being licensed under [Apache 2][LICENSE].
+
+Otherwise, you should make sure that this work is compatible with the [Apache 2][LICENSE] license,
+and discuss with a QSL Team member whether the work should be included and how.
+
+[LICENSE]: ./LICENSE "Quilt Standard Libraries license file"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 This document outlines best-practices and contributing guidelines to the Quilt Standard Libraries.
 
+By contributing to the Quilt Standard Libraries you agree with the [Developer Certificate of Origin (DCO)][DCO].
+
 ## Naming conventions
 
 ### Use of the `$` character
@@ -14,9 +16,11 @@ in other words it allows to separate the actual name of the variable and the nam
 In the case of a pseudo-local variable (a field used briefly to pass around a local variable of a method between 2 injections of said method),
 the field should be named with the namespace first, then the name of the injected method, and finally the name of the local (`quilt$injectedMethod$localName`).
 
-## Licensing
+## Licensing & DCO
 
-QSL is licensed under [Apache 2.0][LICENSE], which means contributions should not introduce incompatibly licensed code.
+QSL is licensed under [Apache 2.0][LICENSE], and have a [Developer Certificate of Origin (DCO)][DCO]
+which you need to agree with to contribute.
+Commit author may be sufficient, but [a sign-off can be added too](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s).
 
 ### License Headers
 
@@ -31,20 +35,15 @@ So, before committing, remember to run `:applyLicenses`!
 
 #### Derivative Work
 
-If your work isn't entirely original, then the default license header should not apply. Here's what to do in different cases:
+Please refer to the [DCO].
 
 ##### My work comes from Fabric API
 
 If your work comes from Fabric API, then you should put `/// FABRIC` at the beginning of your file,
 or in the case you're copying an entire file in it, you can just keep the same header without modification.
 
-Make sure to execute the `:applyLicenses` task as it will apply a special license header to Fabric API-derived files mentioning Fabric's copyright notice. **Files derived from Fabric must use this license header!**
-
-##### My work comes from somewhere else
-
-If the original work is entirely your own, then nothing needs to be done as long as you don't mind it being licensed under [Apache 2][LICENSE].
-
-Otherwise, you should make sure that this work is compatible with the [Apache 2][LICENSE] license
-and discuss with a QSL Team member whether the work can be included and how.
+Make sure to execute the `:applyLicenses` task as it will apply a special license header to Fabric API-derived files mentioning Fabric's copyright notice.
+**Files derived from Fabric must use this license header!**
 
 [LICENSE]: ./LICENSE "Quilt Standard Libraries license file"
+[DCO]: ./DEVELOPER_CERTIFICATE_OF_ORIGIN.md "Developer Certificate of Origin file"

--- a/DEVELOPER_CERTIFICATE_OF_ORIGIN.md
+++ b/DEVELOPER_CERTIFICATE_OF_ORIGIN.md
@@ -1,0 +1,38 @@
+This Developer Certificate of Origin (DCO) is a copy of version 1.1 of the DCO which originated from https://developercertificate.org/.
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+have the right to submit it under the open source license
+indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+of my knowledge, is covered under an appropriate open source
+license and I have the right under that license to submit that
+work with modifications, whether created in whole or in part
+by me, under the same open source license (unless I am
+permitted to submit under a different license), as indicated
+in the file; or
+
+(c) The contribution was provided directly to me by some other
+person who certified (a), (b) or (c) and I have not modified
+it.
+
+(d) I understand and agree that this project and the contribution
+are public and that a record of the contribution (including all
+personal information I submit with it, including my sign-off) is
+maintained indefinitely and may be redistributed consistent with
+this project or the open source license(s) involved.
+```

--- a/build-logic/src/main/groovy/qsl.module.gradle
+++ b/build-logic/src/main/groovy/qsl.module.gradle
@@ -22,18 +22,8 @@ plugins {
 	id("org.quiltmc.loom")
 	// FIXME: This convention plugin is just broken
 	// id("org.quiltmc.gradle-conventions.java.style")
-	id("com.diffplug.spotless")
 	id("org.quiltmc.gradle-conventions.java.version")
 	id("qsl.common")
-}
-
-spotless {
-	java {
-		// UPDATING: This needs to be changed when a new branch is created.
-		// This has been disabled for now due to spotless failing builds always because of something something no remote found in new folders.
-		// ratchetFrom("origin/1.17.1")
-		licenseHeaderFile(rootProject.file("codeformat/HEADER")).yearSeparator(", ")
-	}
 }
 
 def extension = project.extensions.create("qslModule", QslModuleExtension, project)

--- a/build-logic/src/main/java/qsl/internal/Git.java
+++ b/build-logic/src/main/java/qsl/internal/Git.java
@@ -10,13 +10,14 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
+import org.jetbrains.annotations.Nullable;
 
 public final class Git {
 	/**
 	 * Gets the latest commit hash for a project.
-	 * This will do nothing outside of the `library` folder.
+	 * This will do nothing outside the `library` folder.
 	 */
-	public static String getLatestCommitHash(Project project) {
+	public static @Nullable RevCommit getLatestCommit(Project project) {
 		IndraGitExtension indraGit = project.getExtensions().getByType(IndraGitExtension.class);
 
 		if (!indraGit.isPresent()) {
@@ -34,13 +35,27 @@ public final class Git {
 
 			// No commits exist - you will need to create a commit to have a hash
 			if (!iterator.hasNext()) {
-				return "uncommited";
+				return null;
 			}
 
 			// We only care about the last commit
-			return ObjectId.toString(iterator.next());
+			return iterator.next();
 		} catch (GitAPIException | MissingObjectException | IncorrectObjectTypeException e) {
 			throw new GradleException(String.format("Failed to get commit hash of last commit from project %s", project.getName()), e);
+		}
+	}
+
+	/**
+	 * Gets the latest commit hash for a project.
+	 * This will do nothing outside of the `library` folder.
+	 */
+	public static String getLatestCommitHash(Project project) {
+		var commit = getLatestCommit(project);
+
+		if (commit == null) {
+			return "uncommitted";
+		} else {
+			return ObjectId.toString(commit);
 		}
 	}
 

--- a/build-logic/src/main/java/qsl/internal/license/LicenseHeader.java
+++ b/build-logic/src/main/java/qsl/internal/license/LicenseHeader.java
@@ -1,0 +1,314 @@
+package qsl.internal.license;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.jetbrains.annotations.Nullable;
+import qsl.internal.Git;
+
+/**
+ * Represents a license header.
+ */
+public class LicenseHeader {
+	private static final String YEAR_KEY = "$YEAR";
+	private static final String MATCH_FROM_KEY = ";;match_from: ";
+	private final List<Rule> rules;
+
+	public LicenseHeader(Rule... rules) {
+		this.rules = List.of(rules);
+	}
+
+	public LicenseHeader(List<Rule> rules) {
+		this.rules = new ArrayList<>(rules);
+	}
+
+	public boolean validate(Path path) {
+		String source = readFile(path);
+
+		for (var rule : this.rules) {
+			if (rule.match(source)) {
+				return rule.validate(source);
+			}
+		}
+
+		return false;
+	}
+
+	public boolean format(Project project, Path rootPath, Path path) {
+		String source = readFile(path);
+
+		for (var rule : this.rules) {
+			if (rule.match(source)) {
+				return rule.formatFile(project, rootPath, path);
+			}
+		}
+
+		return false;
+	}
+
+	private static String escapeRegexControl(String input) {
+		return input.replace("(", "\\(")
+				.replace(")", "\\)")
+				.replace(".", "\\.")
+				.replace("/", "\\/");
+	}
+
+	private static Pattern getValidator(String headerFormat) {
+		String pattern = escapeRegexControl(headerFormat)
+				.replace(YEAR_KEY, "(\\d{4}(, \\d{4})*)");
+		String[] lines = getHeaderLines(pattern.split("\n"));
+		var patternBuilder = new StringBuilder("\\/\\*\n");
+
+		for (var line : lines) {
+			if (line.isEmpty()) {
+				patternBuilder.append(" \\*\n");
+			} else {
+				patternBuilder.append(" \\* ").append(line).append('\n');
+			}
+		}
+
+		patternBuilder.append(" \\*\\/\n\n");
+
+		return Pattern.compile("^" + patternBuilder);
+	}
+
+	private static @Nullable Pattern getMatcher(String headerFormat) {
+		String[] lines = headerFormat.split("\n");
+		String match = null;
+
+		for (var line : lines) {
+			if (line.startsWith(MATCH_FROM_KEY)) {
+				match = line.substring(MATCH_FROM_KEY.length());
+			}
+		}
+
+		if (match == null) {
+			return null;
+		}
+
+		return Pattern.compile("^/\\*\n \\* " + match);
+	}
+
+	private static String[] getHeaderLines(String[] lines) {
+		int max = lines.length;
+		for (int i = lines.length - 1; i > 0; i--) {
+			if (lines[i].startsWith(";;") || lines[i].isEmpty()) {
+				max = i;
+			} else {
+				break;
+			}
+		}
+
+		var headerLines = new String[max];
+		System.arraycopy(lines, 0, headerLines, 0, max);
+		return headerLines;
+	}
+
+	private static String readFile(Path path) {
+		byte[] bytes;
+
+		try {
+			bytes = Files.readAllBytes(path);
+		} catch (IOException e) {
+			throw new GradleException(String.format("Failed to load file %s", path), e);
+		}
+
+		return new String(bytes, StandardCharsets.UTF_8);
+	}
+
+	private static int getYearStrict(Project project) {
+		RevCommit latestCommit = Git.getLatestCommit(project);
+
+		if (latestCommit == null) {
+			return Calendar.getInstance().get(Calendar.YEAR);
+		} else {
+			PersonIdent authorIdent = latestCommit.getAuthorIdent();
+			Date authorDate = authorIdent.getWhen();
+			TimeZone authorTimeZone = authorIdent.getTimeZone();
+
+			var calendar = Calendar.getInstance(authorTimeZone);
+			calendar.setTime(authorDate);
+			return calendar.get(Calendar.YEAR);
+		}
+	}
+
+	/**
+	 * Represents a license header rule, it describes one valid license header format.
+	 */
+	public static class Rule {
+		private final String headerFormat;
+		private final Pattern validator;
+		private final @Nullable Pattern matcher;
+
+		public Rule(String headerFormat) {
+			this.headerFormat = headerFormat;
+			this.validator = getValidator(headerFormat);
+			this.matcher = getMatcher(headerFormat);
+		}
+
+		public static Rule fromFile(Path path) {
+			byte[] bytes;
+
+			try {
+				bytes = Files.readAllBytes(path);
+			} catch (IOException e) {
+				throw new GradleException(String.format("Failed to load license header %s", path), e);
+			}
+
+			return new Rule(new String(bytes, StandardCharsets.UTF_8));
+		}
+
+		/**
+		 * Returns whether this rule has a special file matching.
+		 *
+		 * @return {@code true} if this rule has a special file matching, otherwise {@code false}
+		 */
+		public final boolean hasSpecialMatching() {
+			return this.matcher != null;
+		}
+
+		/**
+		 * Returns whether the file's licensing should respect this rule.
+		 *
+		 * @param source the source of the file
+		 * @return {@code true} if the file's licensing should respect this rule, otherwise {@code false}
+		 */
+		public boolean match(String source) {
+			if (!this.hasSpecialMatching()) {
+				return true;
+			}
+
+			if (this.matcher.matcher(source).find()) {
+				return true;
+			} else {
+				return this.validator.matcher(source).find();
+			}
+		}
+
+		public boolean validate(String source) {
+			return this.validator.matcher(source).find();
+		}
+
+		public boolean formatFile(Project project, Path rootPath, Path path) {
+			String source = readFile(path);
+			String year = this.getYearString(project, source);
+
+			int delimiter = source.indexOf("package");
+			if (delimiter != -1) {
+				var newSource = this.getLicenseString(year) + source.substring(delimiter);
+
+				if (newSource.equals(source)) {
+					return false;
+				}
+
+				var backupPath = getBackupPath(project, rootPath, path);
+
+				if (backupPath == null) {
+					throw new GradleException("Cannot backup file " + path + ", abandoning formatting.");
+				}
+
+				try {
+					if (!Files.isDirectory(backupPath.getParent())) {
+						Files.createDirectories(backupPath.getParent());
+					}
+
+					Files.copy(path, backupPath, StandardCopyOption.REPLACE_EXISTING);
+				} catch (IOException e) {
+					throw new GradleException("Cannot backup file " + path + ", abandoning formatting.", e);
+				}
+
+				try {
+					Files.writeString(path, newSource);
+				} catch (IOException e) {
+					throw new GradleException("Failed to write updated file " + path + ", abandoning formatting.", e);
+				}
+
+				return true;
+			}
+
+			return false;
+		}
+
+		private String getLicenseString(String year) {
+			var builder = new StringBuilder();
+			var lines = getHeaderLines(this.headerFormat.replace(YEAR_KEY, year).split("\n"));
+
+			builder.append("/*\n");
+			for (var line : lines) {
+				if (line.isEmpty()) {
+					builder.append(" *\n");
+				} else {
+					builder.append(" * ").append(line).append('\n');
+				}
+			}
+
+			builder.append(" */\n\n");
+
+			return builder.toString();
+		}
+
+		private String getYearString(Project project, String source) {
+			int lastYear = getYearStrict(project);
+
+			var matcher = this.validator.matcher(source);
+
+			if (matcher.matches()) {
+				String[] serializedYears = matcher.group(1).split("\n");
+
+				int min = -1;
+				for (var serializedYear : serializedYears) {
+					try {
+						int year = Integer.parseInt(serializedYear);
+
+						if (min == -1 || year < min) {
+							min = year;
+						}
+					} catch (NumberFormatException ignored) {
+						// ignore
+					}
+				}
+
+				if (min == -1) {
+					return String.valueOf(lastYear);
+				} else {
+					return IntStream.range(min, lastYear + 1)
+							.mapToObj(String::valueOf)
+							.collect(Collectors.joining(", "));
+				}
+			}
+
+			return String.valueOf(lastYear);
+		}
+	}
+
+	private static @Nullable Path getBackupPath(Project project, Path rootPath, Path path) {
+		var backupDir = new File(project.getBuildDir(), "qsl/formatter");
+		backupDir.mkdirs();
+		var pathAsString = path.toAbsolutePath().toString();
+		var rootPathAsString = rootPath.toString();
+
+		if (pathAsString.startsWith(rootPathAsString)) {
+			return backupDir.toPath().resolve(Paths.get(pathAsString.substring(rootPathAsString.length() + 1)))
+					.normalize();
+		}
+
+		return null;
+	}
+}

--- a/build-logic/src/main/java/qsl/internal/task/ApplyLicenseTask.java
+++ b/build-logic/src/main/java/qsl/internal/task/ApplyLicenseTask.java
@@ -1,0 +1,55 @@
+package qsl.internal.task;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.tasks.TaskAction;
+import qsl.internal.license.LicenseHeader;
+
+public class ApplyLicenseTask extends JavaSourceBasedTask {
+	private final LicenseHeader licenseHeader;
+
+	@Inject
+	public ApplyLicenseTask(LicenseHeader licenseHeader) {
+		this.licenseHeader = licenseHeader;
+		this.setDescription("Apply the correct license headers to source files.");
+	}
+
+	@TaskAction
+	public void execute() {
+		this.execute(new Consumer(this.licenseHeader));
+	}
+
+	public static class Consumer implements JavaSourceConsumer {
+		private final LicenseHeader licenseHeader;
+		private final List<Path> updatedFiles = new ArrayList<>();
+		private int total = 0;
+
+		public Consumer(LicenseHeader licenseHeader) {
+			this.licenseHeader = licenseHeader;
+		}
+
+		@Override
+		public void consume(Project project, Path rootPath, Path path) {
+			if (this.licenseHeader.format(project, rootPath, path)) {
+				this.updatedFiles.add(path);
+			}
+
+			this.total++;
+		}
+
+		@Override
+		public void end(Logger logger) {
+			for (var path : this.updatedFiles) {
+				logger.lifecycle(" - Updated file {}", path);
+			}
+
+			logger.lifecycle("Updated {} out of {} files.", this.updatedFiles.size(), this.total);
+		}
+	}
+}

--- a/build-logic/src/main/java/qsl/internal/task/CheckLicenseTask.java
+++ b/build-logic/src/main/java/qsl/internal/task/CheckLicenseTask.java
@@ -1,0 +1,64 @@
+package qsl.internal.task;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.tasks.TaskAction;
+import qsl.internal.license.LicenseHeader;
+
+public class CheckLicenseTask extends JavaSourceBasedTask {
+	private final LicenseHeader licenseHeader;
+
+	@Inject
+	public CheckLicenseTask(LicenseHeader licenseHeader) {
+		this.licenseHeader = licenseHeader;
+		this.setDescription("Check whether source files contain a valid license header.");
+	}
+
+	@TaskAction
+	public void execute() {
+		this.execute(new Consumer(this.licenseHeader));
+	}
+
+	public static class Consumer implements JavaSourceConsumer {
+		private final LicenseHeader licenseHeader;
+		private final List<Path> failedChecks = new ArrayList<>();
+		private int total = 0;
+
+		public Consumer(LicenseHeader licenseHeader) {
+			this.licenseHeader = licenseHeader;
+		}
+
+		@Override
+		public void consume(Project project, Path sourceSetPath, Path path) {
+			if (!this.licenseHeader.validate(path)) {
+				this.failedChecks.add(path);
+			}
+
+			this.total++;
+		}
+
+		@Override
+		public void end(Logger logger) {
+			if (this.failedChecks.isEmpty()) {
+				logger.lifecycle("All license header checks passed ({} files).", this.total);
+			} else {
+				for (var failedPath : this.failedChecks) {
+					logger.error(" - {} - license checks have failed.", failedPath);
+				}
+
+				throw new GradleException(
+						String.format("License header checks have failed on %s out of %d files.",
+								this.failedChecks.size(), this.total
+						)
+				);
+			}
+		}
+	}
+}

--- a/build-logic/src/main/java/qsl/internal/task/JavaSourceBasedTask.java
+++ b/build-logic/src/main/java/qsl/internal/task/JavaSourceBasedTask.java
@@ -1,0 +1,35 @@
+package qsl.internal.task;
+
+import java.nio.file.Path;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.plugins.JavaPluginExtension;
+
+public abstract class JavaSourceBasedTask extends DefaultTask {
+	protected void execute(JavaSourceConsumer consumer) {
+		var javaConvention = this.getProject().getExtensions()
+				.getByType(JavaPluginExtension.class);
+
+		for (var sourceSet : javaConvention.getSourceSets()) {
+			for (var javaDir : sourceSet.getAllJava()) {
+				Path sourcePath = javaDir.toPath();
+
+				if (sourcePath.endsWith("package-info.java")) {
+					continue;
+				}
+
+				consumer.consume(this.getProject(), this.getProject().getProjectDir().toPath(), sourcePath);
+			}
+		}
+
+		consumer.end(this.getLogger());
+	}
+
+	public interface JavaSourceConsumer {
+		void consume(Project project, Path sourceSetPath, Path path);
+
+		void end(Logger logger);
+	}
+}

--- a/codeformat/FABRIC_MODIFIED_HEADER
+++ b/codeformat/FABRIC_MODIFIED_HEADER
@@ -12,4 +12,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-;;match_from: Copyright (\(c\) )?2016, 2017, 2018, 2019 FabricMC
+;;match_from: \/\*\n \* Copyright (\(c\) )?2016, 2017, 2018, 2019 FabricMC
+;;match_from: \/\/\/ F[Aa][Bb][Rr][Ii][Cc]

--- a/codeformat/FABRIC_MODIFIED_HEADER
+++ b/codeformat/FABRIC_MODIFIED_HEADER
@@ -1,4 +1,4 @@
-Copyright $YEAR QuiltMC
+Copyright 2016, 2017, 2018, 2019 FabricMC, $YEAR QuiltMC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -11,3 +11,5 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+;;match_from: Copyright (\(c\) )?2016, 2017, 2018, 2019 FabricMC

--- a/library/core/qsl_base/src/main/java/org/quiltmc/qsl/base/api/event/ArrayEvent.java
+++ b/library/core/qsl_base/src/main/java/org/quiltmc/qsl/base/api/event/ArrayEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/reloader/IdentifiableResourceReloader.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/reloader/IdentifiableResourceReloader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/reloader/ResourceReloaderKeys.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/reloader/ResourceReloaderKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/reloader/SimpleResourceReloader.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/reloader/SimpleResourceReloader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/reloader/SimpleSynchronousResourceReloader.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/reloader/SimpleSynchronousResourceReloader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModNioResourcePack.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModNioResourcePack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModResourcePackProvider.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModResourcePackProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModResourcePackUtil.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModResourcePackUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ResourceLoaderImpl.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ResourceLoaderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/KeyedResourceReloaderMixin.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/KeyedResourceReloaderMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/ReloadableResourceManagerImplMixin.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/ReloadableResourceManagerImplMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/FontManagerResourceReloadListenerMixin.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/FontManagerResourceReloadListenerMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/KeyedClientResourceReloaderMixin.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/KeyedClientResourceReloaderMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/library/core/resource_loader/src/testmod/java/org/quiltmc/qsl/resource/loader/test/ResourceReloaderTestMod.java
+++ b/library/core/resource_loader/src/testmod/java/org/quiltmc/qsl/resource/loader/test/ResourceReloaderTestMod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 QuiltMC
+ * Copyright 2016, 2017, 2018, 2019 FabricMC, 2021 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
As the title says.

Replace spotless for a custom solution since it doesn't support conditionals, which is needed for QSL since some files are derived from Fabric API, but some are not.

The custom solution includes checking (`:checkLicenses`) and formatting (`:applyLicenses`).

Also started updating the concerned license headers.

This is an urgent PR.