### PR TITLE
Fix READY lifecycle event being delayed

### DIFF
--- a/library/core/lifecycle_events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/MinecraftServerMixin.java
+++ b/library/core/lifecycle_events/src/main/java/org/quiltmc/qsl/lifecycle/mixin/MinecraftServerMixin.java
@@ -48,7 +48,7 @@ abstract class MinecraftServerMixin {
 			at = @At(
 					value = "INVOKE",
 					target = "Lnet/minecraft/server/MinecraftServer;setFavicon(Lnet/minecraft/server/ServerMetadata;)V",
-					shift = At.Shift.AFTER
+					ordinal = 0
 			)
 	)
 	private void serverReady(CallbackInfo info) {


### PR DESCRIPTION
If another mod mixins to MinecraftServer$runServer at setFavicon, it'll delay the server startup event, which causes issues with [gnembon/fabric-carpet](https://github.com/gnembon/fabric-carpet). This PR fixes that.