### PR TITLE
Support Visual Studio Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 .project
 *.launch
 
+# Visual Studio Code
+.vscode
+
 # Intellij/Idea
 .factorypath
 .idea

--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -33,6 +33,10 @@ dependencies {
 	implementation "io.github.juuxel:loom-quiltflower-mini:1.1.0"
 }
 
+// Visual Studio Code needs these
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
+
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
 	it.options.release.set(17) // Minecraft is Java 17


### PR DESCRIPTION
This adds `.vscode` to .gitignore and adds the Source/Target Compatibility properties since for some reason, VSCode (and apparently Eclipse?) can't get the Java version from options.release