### PR TITLE
Fix the warnings in resource loader

### DIFF
--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/CreateWorldScreenMixin.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/CreateWorldScreenMixin.java
@@ -84,6 +84,7 @@ public class CreateWorldScreenMixin {
 
 	// Lambda method in CreateWorldScreen#applyDataPacks, at CompletableFuture#thenAcceptAsync.
 	// Take a ServerResourceManager parameter.
+	@SuppressWarnings("target")
 	@Inject(
 			method = "m_oezpkwme(Lnet/minecraft/resource/DataPackSettings;Lnet/minecraft/resource/ServerResourceManager;)V",
 			at = @At(
@@ -97,11 +98,13 @@ public class CreateWorldScreenMixin {
 
 	// Lambda method in CreateWorldScreen#applyDataPacks, at CompletableFuture#handle.
 	// Take Void and Throwable parameters.
+	@SuppressWarnings("target")
 	@Inject(
 			method = "m_paskjwcu(Ljava/lang/Void;Ljava/lang/Throwable;)Ljava/lang/Object;",
 			at = @At(
 					value = "INVOKE",
-					target = "Lorg/slf4j/Logger;warn(Ljava/lang/String;Ljava/lang/Throwable;)V"
+					target = "Lorg/slf4j/Logger;warn(Ljava/lang/String;Ljava/lang/Throwable;)V",
+					remap = false
 			)
 	)
 	private void onFailDataPackLoading(Void unused, Throwable throwable, CallbackInfoReturnable<Object> cir) {

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/MinecraftClientMixin.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/MinecraftClientMixin.java
@@ -69,6 +69,7 @@ public class MinecraftClientMixin {
 
 	// Lambda method in MinecraftClient#<init>, at MinecraftClient#setOverlay.
 	// Take an Optional<Throwable> parameter.
+	@SuppressWarnings("target")
 	@Inject(method = "m_aaltpyph(Ljava/util/Optional;)V", at = @At("HEAD"))
 	private void onFirstEndReloadResources(Optional<Throwable> error, CallbackInfo ci) {
 		ClientResourceLoaderEvents.END_RESOURCE_PACK_RELOAD.invoker().onEndResourcePackReload(
@@ -91,6 +92,7 @@ public class MinecraftClientMixin {
 
 	// Lambda method in MinecraftClient#reloadResources, at MinecraftClient#setOverlay.
 	// Take an Optional<Throwable> parameter.
+	@SuppressWarnings("target")
 	@Inject(method = "m_pxfxqhcl(Ljava/util/concurrent/CompletableFuture;Ljava/util/Optional;)V", at = @At(value = "HEAD"))
 	private void onEndReloadResources(CompletableFuture<Void> completableFuture, Optional<Throwable> error, CallbackInfo ci) {
 		ClientResourceLoaderEvents.END_RESOURCE_PACK_RELOAD.invoker().onEndResourcePackReload(


### PR DESCRIPTION
Yay, undocumented methods to suppress warnings! There's also `mapping` for cases where `remap = false` doesn't work in an `@At`