### PR TITLE
Fix registry monitor with registration in 1.18.2, fix Block.asItem() …

### DIFF
--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryMonitor.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryMonitor.java
@@ -45,7 +45,10 @@ public interface RegistryMonitor<V> {
 	 * Registers the specified callback to be invoked for <b>every entry ever</b> to be registered in the monitor's registry.
 	 * <p>
 	 * Entries must also match the monitor's filters.
-	 *
+	 * <p>
+	 * Registration inside the callback must use the {@link RegistryEntryContext#registry()} method to get the registry instance,
+	 * for example: {@code Registry.register(context.registry(), id, block);}.
+ 	 *
 	 * @param callback the callback to be invoked on entries
 	 */
 	void forAll(RegistryEvents.EntryAdded<V> callback);

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/event/DelayedRegistry.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/event/DelayedRegistry.java
@@ -191,12 +191,12 @@ public final class DelayedRegistry<T> extends MutableRegistry<T> {
 
 	@Override
 	public void resetTags() {
-		// noop
+		throw new UnsupportedOperationException("DelayedRegistry does not support resetTags.");
 	}
 
 	@Override
 	public void bindTags(Map<TagKey<T>, List<Holder<T>>> tags) {
-		// noop
+		throw new UnsupportedOperationException("DelayedRegistry does not support bindTags.");
 	}
 
 	@Override

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/event/DelayedRegistry.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/event/DelayedRegistry.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2021-2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.registry.impl.event;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Queue;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.Lifecycle;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.tag.TagKey;
+import net.minecraft.util.Holder;
+import net.minecraft.util.HolderSet;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.MutableRegistry;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryKey;
+
+import org.quiltmc.qsl.registry.mixin.SimpleRegistryAccessor;
+
+@ApiStatus.Internal
+public final class DelayedRegistry<T> extends MutableRegistry<T> {
+	private final MutableRegistry<T> wrapped;
+	private final Queue<DelayedEntry<T>> delayedEntries = new LinkedList<>();
+
+	private final @Nullable Function<T, Holder.Reference<T>> customHolderProvider;
+
+	@SuppressWarnings("unchecked")
+	DelayedRegistry(MutableRegistry<T> registry) {
+		super(registry.getKey(), registry.getLifecycle());
+
+		this.wrapped = registry;
+
+		if (registry instanceof SimpleRegistryAccessor simpleRegistry) {
+			this.customHolderProvider = simpleRegistry.getCustomHolderProvider();
+		} else {
+			this.customHolderProvider = null;
+		}
+	}
+
+	@Override
+	public @Nullable Identifier getId(T entry) {
+		return this.wrapped.getId(entry);
+	}
+
+	@Override
+	public Optional<RegistryKey<T>> getKey(T entry) {
+		return this.wrapped.getKey(entry);
+	}
+
+	@Override
+	public int getRawId(@Nullable T entry) {
+		return this.wrapped.getRawId(entry);
+	}
+
+	@Override
+	public @Nullable T get(int index) {
+		return this.wrapped.get(index);
+	}
+
+	@Override
+	public int size() {
+		return this.wrapped.size();
+	}
+
+	@Override
+	public @Nullable T get(@Nullable RegistryKey<T> key) {
+		return this.wrapped.get(key);
+	}
+
+	@Override
+	public @Nullable T get(@Nullable Identifier id) {
+		return this.wrapped.get(id);
+	}
+
+	@Override
+	public Lifecycle getEntryLifecycle(T entry) {
+		return this.wrapped.getEntryLifecycle(entry);
+	}
+
+	@Override
+	public Lifecycle getLifecycle() {
+		return this.wrapped.getLifecycle();
+	}
+
+	@Override
+	public Set<Identifier> getIds() {
+		return this.wrapped.getIds();
+	}
+
+	@Override
+	public Set<Map.Entry<RegistryKey<T>, T>> getEntries() {
+		return this.wrapped.getEntries();
+	}
+
+	@Override
+	public Set<RegistryKey<T>> method_42021() {
+		return this.wrapped.method_42021();
+	}
+
+	@Override
+	public Optional<Holder<T>> getRandom(Random random) {
+		return this.wrapped.getRandom(random);
+	}
+
+	@Override
+	public boolean containsId(Identifier id) {
+		return this.wrapped.containsId(id);
+	}
+
+	@Override
+	public boolean contains(RegistryKey<T> key) {
+		return this.wrapped.contains(key);
+	}
+
+	@Override
+	public Registry<T> freeze() {
+		// Refuse freezing.
+		return this;
+	}
+
+	@Override
+	public Holder<T> getOrCreateHolder(RegistryKey<T> key) {
+		return this.wrapped.getOrCreateHolder(key);
+	}
+
+	@Override
+	public Holder.Reference<T> createIntrusiveHolder(T holder) {
+		return this.wrapped.createIntrusiveHolder(holder);
+	}
+
+	@Override
+	public Optional<Holder<T>> getHolder(int index) {
+		return this.wrapped.getHolder(index);
+	}
+
+	@Override
+	public Optional<Holder<T>> getHolder(RegistryKey<T> key) {
+		return this.wrapped.getHolder(key);
+	}
+
+	@Override
+	public Stream<Holder.Reference<T>> holders() {
+		return this.wrapped.holders();
+	}
+
+	@Override
+	public Optional<HolderSet.NamedSet<T>> getTag(TagKey<T> tag) {
+		return this.wrapped.getTag(tag);
+	}
+
+	@Override
+	public HolderSet.NamedSet<T> getOrCreateTag(TagKey<T> key) {
+		return this.wrapped.getOrCreateTag(key);
+	}
+
+	@Override
+	public Stream<Pair<TagKey<T>, HolderSet.NamedSet<T>>> getTags() {
+		return this.wrapped.getTags();
+	}
+
+	@Override
+	public Stream<TagKey<T>> getTagKeys() {
+		return this.wrapped.getTagKeys();
+	}
+
+	@Override
+	public boolean isKnownTag(TagKey<T> tag) {
+		return this.wrapped.isKnownTag(tag);
+	}
+
+	@Override
+	public void resetTags() {
+		// noop
+	}
+
+	@Override
+	public void bindTags(Map<TagKey<T>, List<Holder<T>>> tags) {
+		// noop
+	}
+
+	@Override
+	public Iterator<T> iterator() {
+		return this.wrapped.iterator();
+	}
+
+	@Override
+	public Holder<T> set(int rawId, RegistryKey<T> key, T entry, Lifecycle lifecycle) {
+		throw new UnsupportedOperationException("DelayedRegistry does not support set.");
+	}
+
+	@Override
+	public Holder<T> register(RegistryKey<T> key, T entry, Lifecycle lifecycle) {
+		this.delayedEntries.add(new DelayedEntry<>(key, entry, lifecycle));
+
+		if (this.customHolderProvider != null) {
+			return this.customHolderProvider.apply(entry);
+		}
+
+		return new Holder.Direct<>(entry);
+	}
+
+	@Override
+	public Holder<T> replace(OptionalInt rawId, RegistryKey<T> key, T newEntry, Lifecycle lifecycle) {
+		throw new UnsupportedOperationException("DelayedRegistry does not support replacement.");
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return this.wrapped.isEmpty();
+	}
+
+	void applyDelayed() {
+		DelayedEntry<T> entry;
+
+		while ((entry = this.delayedEntries.poll()) != null) {
+			this.wrapped.register(entry.key(), entry.entry(), entry.lifecycle());
+		}
+	}
+
+	record DelayedEntry<T>(RegistryKey<T> key, T entry, Lifecycle lifecycle) {
+	}
+}

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/event/DelayedRegistry.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/event/DelayedRegistry.java
@@ -119,11 +119,6 @@ public final class DelayedRegistry<T> extends MutableRegistry<T> {
 	}
 
 	@Override
-	public Set<RegistryKey<T>> method_42021() {
-		return this.wrapped.method_42021();
-	}
-
-	@Override
 	public Optional<Holder<T>> getRandom(Random random) {
 		return this.wrapped.getRandom(random);
 	}

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/event/RegistryMonitorImpl.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/event/RegistryMonitorImpl.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 import net.minecraft.util.Holder;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.SimpleRegistry;
 
 import org.quiltmc.qsl.registry.api.event.RegistryEntryContext;
 import org.quiltmc.qsl.registry.api.event.RegistryEvents;
@@ -54,11 +55,12 @@ public class RegistryMonitorImpl<V> implements RegistryMonitor<V> {
 	@Override
 	@SuppressWarnings("unchecked")
 	public void forAll(RegistryEvents.EntryAdded<V> callback) {
-		var context = new MutableRegistryEntryContextImpl<>(this.registry);
-
 		if (!(this.registry instanceof SimpleRegistryAccessor)) {
 			throw new UnsupportedOperationException("Registry " + this.registry + " is not supported!");
 		}
+
+		var delayed = new DelayedRegistry<>((SimpleRegistry<V>) this.registry);
+		var context = new MutableRegistryEntryContextImpl<>(delayed);
 
 		for (Map.Entry<Identifier, Holder.Reference<V>> entry : ((SimpleRegistryAccessor<V>) this.registry).getById().entrySet()) {
 			context.set(entry.getKey(), entry.getValue().value());
@@ -69,6 +71,8 @@ public class RegistryMonitorImpl<V> implements RegistryMonitor<V> {
 		}
 
 		this.forUpcoming(callback);
+
+		delayed.applyDelayed();
 	}
 
 	@Override

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/mixin/ItemsMixin.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/mixin/ItemsMixin.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021-2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.registry.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+import net.minecraft.util.registry.Registry;
+
+import org.quiltmc.qsl.registry.api.event.RegistryMonitor;
+
+@Mixin(Items.class)
+public abstract class ItemsMixin {
+	@Inject(method = "<clinit>", at = @At("RETURN"))
+	private static void onInit(CallbackInfo ci) {
+		RegistryMonitor.create(Registry.ITEM)
+				.filter(context -> context.value() instanceof BlockItem)
+				.forUpcoming(context -> ((BlockItem) context.value()).appendBlocks(Item.BLOCK_ITEMS, context.value()));
+	}
+}

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/mixin/SimpleRegistryAccessor.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/mixin/SimpleRegistryAccessor.java
@@ -17,7 +17,9 @@
 package org.quiltmc.qsl.registry.mixin;
 
 import java.util.Map;
+import java.util.function.Function;
 
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
@@ -33,4 +35,7 @@ import net.minecraft.util.registry.SimpleRegistry;
 public interface SimpleRegistryAccessor<V> {
 	@Accessor("byId")
 	Map<Identifier, Holder.Reference<V>> getById();
+
+	@Accessor
+	@Nullable Function<V, Holder.Reference<V>> getCustomHolderProvider();
 }

--- a/library/core/registry/src/main/resources/quilt_registry.mixins.json
+++ b/library/core/registry/src/main/resources/quilt_registry.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "DebugChunkGeneratorAccessor",
+    "ItemsMixin",
     "RegistryMixin",
     "SimpleRegistryAccessor",
     "SimpleRegistryMixin"

--- a/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibEventsTest.java
+++ b/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibEventsTest.java
@@ -48,10 +48,14 @@ public class RegistryLibEventsTest implements ModInitializer {
 			}
 		});
 
-		Registry.register(Registry.BLOCK, TEST_BLOCK_ID, new Block(AbstractBlock.Settings.of(Material.STONE, MapColor.BLACK)));
+		register(TEST_BLOCK_ID, new Block(AbstractBlock.Settings.of(Material.STONE, MapColor.BLACK)));
 
 		if (!entryAddEventFoundBlock) {
 			throw new AssertionError("Registry entry add event was not invoked on the registration of block with id " + TEST_BLOCK_ID);
 		}
+	}
+
+	static <T extends Block> T register(Identifier id, T block) {
+		return Registry.register(Registry.BLOCK, id, block);
 	}
 }

--- a/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibMonitorRegistrationTest.java
+++ b/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibMonitorRegistrationTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021-2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.registry.test;
+
+import static org.quiltmc.qsl.registry.test.RegistryLibEventsTest.register;
+
+import net.fabricmc.loader.api.ModContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.MapColor;
+import net.minecraft.block.Material;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+import org.quiltmc.qsl.base.api.entrypoint.ModInitializer;
+import org.quiltmc.qsl.registry.api.event.RegistryMonitor;
+
+/**
+ * Tests whether a ConcurrentModificationException happens or not.
+ * <p>
+ * This module should attempt to avoid CMEs.
+ */
+public class RegistryLibMonitorRegistrationTest implements ModInitializer {
+	private static final Logger LOGGER = LoggerFactory.getLogger("Quilt Registry Lib Monitor Registration Test");
+
+	private static final Identifier TEST_BLOCK_A_ID = new Identifier("quilt_registry_test_monitors_registration", "test_block_a");
+	private static final Identifier TEST_BLOCK_B_ID = new Identifier("quilt_registry_test_monitors_registration", "test_block_b");
+
+	@Override
+	public void onInitialize(ModContainer mod) {
+		register(TEST_BLOCK_A_ID, new Block(AbstractBlock.Settings.of(Material.STONE, MapColor.BLACK)));
+
+		var monitor = RegistryMonitor.create(Registry.BLOCK)
+				.filter(context -> context.id().getNamespace().equals("quilt_registry_test_monitors_registration"));
+
+		monitor.forAll(context -> {
+			LOGGER.info("[forAll event]: Block {} id={} raw={} had its registration monitored in registry {}",
+					context.value(), context.id(), context.rawId(), context.registry());
+
+			if (context.id() == TEST_BLOCK_A_ID) {
+				Registry.register(context.registry(), TEST_BLOCK_B_ID, new Block(AbstractBlock.Settings.of(Material.STONE, MapColor.BLACK)));
+			}
+		});
+	}
+}

--- a/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibMonitorTest.java
+++ b/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibMonitorTest.java
@@ -16,6 +16,8 @@
 
 package org.quiltmc.qsl.registry.test;
 
+import static org.quiltmc.qsl.registry.test.RegistryLibEventsTest.register;
+
 import java.util.HashSet;
 
 import net.fabricmc.loader.api.ModContainer;
@@ -40,7 +42,7 @@ public class RegistryLibMonitorTest implements ModInitializer {
 
 	@Override
 	public void onInitialize(ModContainer mod) {
-		Block blockA = Registry.register(Registry.BLOCK, TEST_BLOCK_A_ID, new Block(AbstractBlock.Settings.of(Material.STONE, MapColor.BLACK)));
+		Block blockA = register(TEST_BLOCK_A_ID, new Block(AbstractBlock.Settings.of(Material.STONE, MapColor.BLACK)));
 
 		var monitor = RegistryMonitor.create(Registry.BLOCK)
 				.filter(context -> context.id().getNamespace().equals("quilt_registry_test_monitors"));
@@ -59,7 +61,7 @@ public class RegistryLibMonitorTest implements ModInitializer {
 			upcomingSet.add(context.value());
 		});
 
-		Block blockB = Registry.register(Registry.BLOCK, TEST_BLOCK_B_ID, new Block(AbstractBlock.Settings.of(Material.STONE, MapColor.BLACK)));
+		Block blockB = register(TEST_BLOCK_B_ID, new Block(AbstractBlock.Settings.of(Material.STONE, MapColor.BLACK)));
 
 		if (!allSet.contains(blockA) || !allSet.contains(blockB)) {
 			throw new AssertionError("Entries " + allSet + " found by RegistryMonitor via forAll were not as expected");

--- a/library/core/registry/src/testmod/resources/fabric.mod.json
+++ b/library/core/registry/src/testmod/resources/fabric.mod.json
@@ -11,6 +11,7 @@
   "entrypoints": {
     "init": [
       "org.quiltmc.qsl.registry.test.RegistryLibEventsTest",
+      "org.quiltmc.qsl.registry.test.RegistryLibMonitorRegistrationTest",
       "org.quiltmc.qsl.registry.test.RegistryLibMonitorTest"
     ]
   }


### PR DESCRIPTION
…with modded.

This oversight has not been caught when porting due to a missing test.

This PR introduces a proxy object for the registry which delays registration.