### PR TITLE
Add a method for quick registration in RegistryEntryContext.

### DIFF
--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryEntryContext.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryEntryContext.java
@@ -50,7 +50,7 @@ public interface RegistryEntryContext<V> {
 	/**
 	 * Safely registers a new entry in the registry of this context.
 	 * <p>
-	 * Registration may be delayed with {@link RegistryMonitor#forAll(RegistryEvents.EntryAdded)}.
+	 * Registration may be delayed when called from {@link RegistryMonitor#forAll(RegistryEvents.EntryAdded)}.
 	 *
 	 * @param id    the identifier of the entry
 	 * @param value the value to register

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryEntryContext.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryEntryContext.java
@@ -46,4 +46,18 @@ public interface RegistryEntryContext<V> {
 	 * {@return the entry's raw int identifier}
 	 */
 	int rawId();
+
+	/**
+	 * Safely registers a new entry in the registry of this context.
+	 * <p>
+	 * Registration may be delayed with {@link RegistryMonitor#forAll(RegistryEvents.EntryAdded)}.
+	 *
+	 * @param id    the identifier of the entry
+	 * @param value the value to register
+	 * @param <T>   the type of the value
+	 * @return the registered value
+	 */
+	default <T extends V> T register(Identifier id, T value) {
+		return Registry.register(this.registry(), id, value);
+	}
 }

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryMonitor.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryMonitor.java
@@ -47,8 +47,8 @@ public interface RegistryMonitor<V> {
 	 * <p>
 	 * Entries must also match the monitor's filters.
 	 * <p>
- 	 * Registration to the registry being iterated must use the {@link RegistryEntryContext#registry()} method to get the registry instance inside the callback,
-	 * or alternatively use the {@link RegistryEntryContext#register(Identifier, Object)} method,
+ 	 * Registration to the registry being iterated must use the {@link RegistryEntryContext#register(Identifier, Object)} method inside the callback,
+	 * or alternatively use the {@link RegistryEntryContext#registry()} method to get the registry instance,
 	 * for example: {@code context.register(id, block);}.
  	 *
 	 * @param callback the callback to be invoked on entries

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryMonitor.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryMonitor.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 
 import org.jetbrains.annotations.ApiStatus;
 
+import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
 import org.quiltmc.qsl.registry.impl.event.RegistryMonitorImpl;
@@ -47,7 +48,8 @@ public interface RegistryMonitor<V> {
 	 * Entries must also match the monitor's filters.
 	 * <p>
 	 * Registration inside the callback must use the {@link RegistryEntryContext#registry()} method to get the registry instance,
-	 * for example: {@code Registry.register(context.registry(), id, block);}.
+	 * or alternatively use the {@link RegistryEntryContext#register(Identifier, Object)} method,
+	 * for example: {@code context.register(id, block);}.
  	 *
 	 * @param callback the callback to be invoked on entries
 	 */

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryMonitor.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryMonitor.java
@@ -47,7 +47,7 @@ public interface RegistryMonitor<V> {
 	 * <p>
 	 * Entries must also match the monitor's filters.
 	 * <p>
-	 * Registration inside the callback must use the {@link RegistryEntryContext#registry()} method to get the registry instance,
+ 	 * Registration to the registry being iterated must use the {@link RegistryEntryContext#registry()} method to get the registry instance inside the callback,
 	 * or alternatively use the {@link RegistryEntryContext#register(Identifier, Object)} method,
 	 * for example: {@code context.register(id, block);}.
  	 *

--- a/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibMonitorRegistrationTest.java
+++ b/library/core/registry/src/testmod/java/org/quiltmc/qsl/registry/test/RegistryLibMonitorRegistrationTest.java
@@ -55,7 +55,7 @@ public class RegistryLibMonitorRegistrationTest implements ModInitializer {
 					context.value(), context.id(), context.rawId(), context.registry());
 
 			if (context.id() == TEST_BLOCK_A_ID) {
-				Registry.register(context.registry(), TEST_BLOCK_B_ID, new Block(AbstractBlock.Settings.of(Material.STONE, MapColor.BLACK)));
+				context.register(TEST_BLOCK_B_ID, new Block(AbstractBlock.Settings.of(Material.STONE, MapColor.BLACK)));
 			}
 		});
 	}


### PR DESCRIPTION
Rationale: is more visible as it's directly in the context object, may avoid issues.