### PR TITLE
QSL Versioning, initial draft

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "17"
-      - uses: actions/checkout@v2 # Required for indra-git
+      - uses: actions/checkout@v2
       - run: ./gradlew checkVersion build publish -stacktrace
         env:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -1,5 +1,5 @@
-name: Test
-on: [push, pull_request]
+name: Publish Snapshot
+on: [push]
 
 jobs:
   build:
@@ -14,11 +14,12 @@ jobs:
           distribution: "temurin"
           java-version: ${{ matrix.java }}
       - uses: actions/checkout@v2
-      - run: ./gradlew check build publishToMavenLocal --stacktrace --parallel
-      - run: mkdir run && echo "eula=true" >> run/eula.txt
-      - run: ./gradlew :runAutoTestServer --stacktrace
-      #- run: mkdir run && echo "eula=true" >> run/eula.txt
-      #- run: ./gradlew :runAutoTestServer --stacktrace
+      - run: ./gradlew build publish --stacktrace --parallel
+        env:
+          SNAPSHOTS_URL: ${{ secrets.SNAPSHOTS_URL }}
+          SNAPSHOTS_USERNAME: ${{ secrets.SNAPSHOTS_USERNAME }}
+          SNAPSHOTS_PASSWORD: ${{ secrets.SNAPSHOTS_PASSWORD }}
+
       - uses: actions/upload-artifact@v2
         with:
           name: Artifacts

--- a/build-logic/src/main/groovy/qsl.common.gradle
+++ b/build-logic/src/main/groovy/qsl.common.gradle
@@ -11,6 +11,8 @@ plugins {
 
 def ENV = System.getenv()
 
+version = rootProject.version
+
 publishing {
 	repositories {
 		if (ENV.MAVEN_URL) {

--- a/build-logic/src/main/groovy/qsl.library.gradle
+++ b/build-logic/src/main/groovy/qsl.library.gradle
@@ -96,6 +96,12 @@ afterEvaluate {
 	}
 
 	loom.disableDeprecatedPomGeneration(publishing.publications.mavenJava)
+
+	// Print the version and throw an exception if it doesn't match
+	if (version != rootProject.version) {
+		throw new GradleException("Library ${extension.libraryName.get()} version ($version) does not match root project version ($rootProject.version). Do not change it!")
+
+	}
 }
 
 // A library isn't truly a distributed artifact, rather it is just maven metadata to depend on the modules of a library.
@@ -134,7 +140,30 @@ project.getTasksByName("checkModuleVersion", true).each {
 	checkLibVersion.mustRunAfter it
 }
 
+publishing {
+	repositories {
+		mavenLocal()
+	}
 
+	publications {
+		mavenJava(MavenPublication) {
+			pom.withXml {
+				asNode().appendNode("properties").appendNode("hash", Git.getLatestCommitHash(project))
+				def depsNode = asNode().appendNode("dependencies")
+				rootProject.subprojects.stream().filter {
+					it.path.startsWith(":${extension.libraryName.get()}:")
+				}.forEach {
+					def depNode = depsNode.appendNode("dependency")
+					depNode.appendNode("groupId", it.group)
+					depNode.appendNode("artifactId", it.name)
+					depNode.appendNode("version", it.version)
+					depNode.appendNode("scope", "compile")
+				}
+			}
+		}
+	}
+}
 
+loom.disableDeprecatedPomGeneration(publishing.publications.mavenJava)
 
 publish.dependsOn checkLibVersion

--- a/build-logic/src/main/groovy/qsl.library.gradle
+++ b/build-logic/src/main/groovy/qsl.library.gradle
@@ -79,7 +79,6 @@ afterEvaluate {
 		publications {
 			mavenJava(MavenPublication) {
 				pom.withXml {
-					asNode().appendNode("properties").appendNode("hash", Git.getLatestCommitHash(project))
 					def depsNode = asNode().appendNode("dependencies")
 					rootProject.subprojects.stream().filter {
 						it.path.startsWith(":${extension.libraryName.get()}:")
@@ -118,52 +117,6 @@ remapJar {
 	enabled = false
 }
 
-task checkLibVersion {
-	doFirst {
-		def libraryName = extension.libraryName.get()
-
-		try {
-			def xml = new URL("https://maven.quiltmc.org/repository/release/org/quiltmc/qsl/$libraryName/$project.version/" +
-					"$libraryName-$project.version" + ".pom").text
-			def metadata = new groovy.xml.XmlSlurper().parseText(xml)
-
-			if (metadata.properties.hash != Git.getLatestCommitHash(project)) {
-				throw new RuntimeException("Library is already published with a different hash!")
-			}
-		} catch (FileNotFoundException ignored) {
-			//
-		}
-	}
-}
-
 project.getTasksByName("checkModuleVersion", true).each {
 	checkLibVersion.mustRunAfter it
 }
-
-publishing {
-	repositories {
-		mavenLocal()
-	}
-
-	publications {
-		mavenJava(MavenPublication) {
-			pom.withXml {
-				asNode().appendNode("properties").appendNode("hash", Git.getLatestCommitHash(project))
-				def depsNode = asNode().appendNode("dependencies")
-				rootProject.subprojects.stream().filter {
-					it.path.startsWith(":${extension.libraryName.get()}:")
-				}.forEach {
-					def depNode = depsNode.appendNode("dependency")
-					depNode.appendNode("groupId", it.group)
-					depNode.appendNode("artifactId", it.name)
-					depNode.appendNode("version", it.version)
-					depNode.appendNode("scope", "compile")
-				}
-			}
-		}
-	}
-}
-
-loom.disableDeprecatedPomGeneration(publishing.publications.mavenJava)
-
-publish.dependsOn checkLibVersion

--- a/build-logic/src/main/groovy/qsl.module.gradle
+++ b/build-logic/src/main/groovy/qsl.module.gradle
@@ -41,10 +41,6 @@ afterEvaluate {
 	}
 
 	group = "org.quiltmc.qsl.${extension.library.get()}"
-	// Version is set automatically in extension, verify it is set.
-	if (project.version == "unspecified") { // Gradle will return `unspecified` given no version being set.
-		throw new GradleException("Module $extension.moduleName needs a version to be set in the qslModule extension")
-	}
 
 
 	publishing {
@@ -81,6 +77,9 @@ afterEvaluate {
 
 	(extension as QslModuleExtensionImpl).setupModuleDependencies()
 	// TODO: Anything else to validate.
+	if (version != rootProject.version) {
+		throw new GradleException("Module ${extension.moduleName.get()} version ($version) does not match root project version ($rootProject.version). Do not change it!")
+	}
 }
 
 

--- a/build-logic/src/main/groovy/qsl.module.gradle
+++ b/build-logic/src/main/groovy/qsl.module.gradle
@@ -184,24 +184,3 @@ license {
 	include "**/*.java"
 }
 
-task checkModuleVersion {
-	doFirst {
-		def moduleName = extension.moduleName.get()
-		def library = extension.library.get()
-
-		try {
-			def xml = new URL("https://maven.quiltmc.org/repository/release/org/quiltmc/qsl/$library/$moduleName/$project.version/" +
-					"$moduleName-$project.version" + ".pom").text
-			def metadata = new groovy.xml.XmlSlurper().parseText(xml)
-
-			if (metadata.properties.hash != Git.getLatestCommitHash(project)) {
-				throw new RuntimeException("A module is already published with a different hash!")
-			}
-		} catch (FileNotFoundException ignored) {
-			// No existing version of the module was found.
-		}
-	}
-}
-
-
-publish.dependsOn checkModuleVersion

--- a/build-logic/src/main/java/qsl/internal/Versions.java
+++ b/build-logic/src/main/java/qsl/internal/Versions.java
@@ -17,7 +17,7 @@ public final class Versions {
 	/**
 	 * The QSL version
 	 */
-	public static final String QSL_VERSION = "0.1.0";
+	public static final String QSL_VERSION = "1.1.0-beta.1";
 
 	/**
 	 * The target Minecraft version.

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,12 @@ plugins {
 def ENV = System.getenv()
 group = "org.quiltmc"
 version = Versions.QSL_VERSION
-// Takes "1.0.0-beta.1" and changes it to "1.0.0-beta.2.snapshot, unless we are releasing.
+
+// Takes "1.0.0-beta.1" and changes it to "1.0.0-beta.2, unless we are releasing.
+// TODO: there is no way to semantically identify if a release is a snapshot or not right now
 if (version.contains("beta") && !ENV.MAVEN_URL) {
 	int beta = Integer.parseInt(version.substring(version.indexOf("beta.") + 5))
 	version = version.replace(version.substring(version.indexOf("beta.")), "beta." + (beta + 1))
-	// this seems redundant, but its necessary to make sure the version is considered "older" than the full release
-	version = version + ".snapshot"
 }
 
 version = version + "+" + Versions.MINECRAFT_VERSION + (System.getenv("SNAPSHOTS_URL") ? "-SNAPSHOT" : "")

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,19 @@ plugins {
 	id("org.jetbrains.gradle.plugin.idea-ext") version("1.1.3")
 	id("qsl.common")
 }
-
+def ENV = System.getenv()
 group = "org.quiltmc.qsl"
-version = Versions.QSL_VERSION + "+" + Versions.MINECRAFT_VERSION + (System.getenv("SNAPSHOTS_URL") ? "-SNAPSHOT" : "")
+version = Versions.QSL_VERSION
+// Takes "1.0.0-beta.1" and changes it to "1.0.0-beta.2.snapshot, unless we are releasing.
+if (version.contains("beta") && !ENV.MAVEN_URL) {
+	int beta = Integer.parseInt(version.substring(version.indexOf("beta.") + 5))
+	version = version.replace(version.substring(version.indexOf("beta.")), "beta." + (beta + 1))
+	// this seems redundant, but its necessary to make sure the version is considered "older" than the full release
+	version = version + ".snapshot"
+}
 
+version = version + "+" + Versions.MINECRAFT_VERSION + (System.getenv("SNAPSHOTS_URL") ? "-SNAPSHOT" : "")
+println("QSL: " + version)
 sourceSets {
 	testmod {
 		compileClasspath += main.compileClasspath
@@ -108,7 +117,6 @@ afterEvaluate {
 		}
 	}
 }
-
 
 task checkVersion {
 	doFirst {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 	id("qsl.common")
 }
 def ENV = System.getenv()
-group = "org.quiltmc.qsl"
+group = "org.quiltmc"
 version = Versions.QSL_VERSION
 // Takes "1.0.0-beta.1" and changes it to "1.0.0-beta.2.snapshot, unless we are releasing.
 if (version.contains("beta") && !ENV.MAVEN_URL) {

--- a/library/block/block_extensions/build.gradle
+++ b/library/block/block_extensions/build.gradle
@@ -7,7 +7,6 @@ qslModule {
 	moduleName = "block_extensions"
 	id = "quilt_block_extensions"
 	description = "Extensions for creating and working with blocks."
-	version = "1.0.0"
 	library = "block"
 	moduleDependencies {
 		core {

--- a/library/block/build.gradle
+++ b/library/block/build.gradle
@@ -4,5 +4,4 @@ plugins {
 
 qslLibrary {
 	libraryName = "block"
-	version = "1.0.0"
 }

--- a/library/command/build.gradle
+++ b/library/command/build.gradle
@@ -4,5 +4,4 @@ plugins {
 
 qslLibrary {
 	libraryName = "command"
-	version = "1.0.0"
 }

--- a/library/command/client_command/build.gradle
+++ b/library/command/client_command/build.gradle
@@ -6,7 +6,6 @@ qslModule {
 	name = "Quilt Client Command API"
 	moduleName = "client_command"
 	id = "quilt_client_command"
-	version = "1.0.0"
 	description = "Quilt APIs for creating and managing client-side commands."
 	library = "command"
 	moduleDependencies {

--- a/library/command/command/build.gradle
+++ b/library/command/command/build.gradle
@@ -7,7 +7,6 @@ qslModule {
 	moduleName = "command"
 	id = "quilt_command"
 	description = "Quilt APIs relating to commands."
-	version = "1.0.0"
 	library = "command"
 	moduleDependencies {
 		core {

--- a/library/core/build.gradle
+++ b/library/core/build.gradle
@@ -4,5 +4,4 @@ plugins {
 
 qslLibrary {
 	libraryName = "core"
-	version = "1.0.0"
 }

--- a/library/core/crash_info/build.gradle
+++ b/library/core/crash_info/build.gradle
@@ -8,7 +8,6 @@ qslModule {
 	id = "quilt_crash_info"
 	description = "Adds information about the Quilt environment to crash reports," +
 			" and allows other mods to do the same."
-	version = "1.0.0"
 	library = "core"
 	moduleDependencies {
 		core {

--- a/library/core/lifecycle_events/build.gradle
+++ b/library/core/lifecycle_events/build.gradle
@@ -7,7 +7,6 @@ qslModule {
 	moduleName = "lifecycle_events"
 	description = "Events to track the lifecycle of Minecraft."
 	id = "quilt_lifecycle_events"
-	version = "1.0.0"
 	library = "core"
 	moduleDependencies {
 		core {

--- a/library/core/networking/build.gradle
+++ b/library/core/networking/build.gradle
@@ -7,7 +7,6 @@ qslModule {
 	moduleName = "networking"
 	id = "quilt_networking"
 	description = "Utilites to assist with sending custom packets over the Minecraft protocol."
-	version = "1.0.0"
 	library = "core"
 	moduleDependencies {
 		core {

--- a/library/core/qsl_base/build.gradle
+++ b/library/core/qsl_base/build.gradle
@@ -7,7 +7,6 @@ qslModule {
 	moduleName = "qsl_base"
 	id = "quilt_base"
 	description = "Basic APIs for Quilt mods, such as events and entrypoints."
-	version = "1.0.0"
 	library = "core"
 	entrypoints {
 		init {

--- a/library/core/registry/build.gradle
+++ b/library/core/registry/build.gradle
@@ -7,7 +7,6 @@ qslModule {
 	moduleName = "registry"
 	id = "quilt_registry"
 	description = "Tools and events for manipulating and monitoring Minecraft's content registries."
-	version = "1.0.0"
 	library = "core"
 	moduleDependencies {
 		core {

--- a/library/core/resource_loader/build.gradle
+++ b/library/core/resource_loader/build.gradle
@@ -7,7 +7,6 @@ qslModule {
 	moduleName = "resource_loader"
 	id = "quilt_resource_loader"
 	description = "Asset and data resource loading for Quilt mods."
-	version = "1.0.0"
 	library = "core"
 	moduleDependencies {
 		core {

--- a/library/data/build.gradle
+++ b/library/data/build.gradle
@@ -4,5 +4,4 @@ plugins {
 
 qslLibrary {
 	libraryName = "data"
-	version = "1.0.0"
 }

--- a/library/data/tags/build.gradle
+++ b/library/data/tags/build.gradle
@@ -7,7 +7,6 @@ qslModule {
 	moduleName = "tags"
 	id = "quilt_tags"
 	description = "Tag loading and management."
-	version = "1.0.0"
 	library = "data"
 	moduleDependencies {
 		core {

--- a/library/gui/build.gradle
+++ b/library/gui/build.gradle
@@ -4,5 +4,4 @@ plugins {
 
 qslLibrary {
 	libraryName = "gui"
-	version = "1.0.0"
 }

--- a/library/gui/tooltip/build.gradle
+++ b/library/gui/tooltip/build.gradle
@@ -7,7 +7,6 @@ qslModule {
 	moduleName = "tooltip"
 	id = "quilt_tooltip"
 	description = "Hooks and APIs for manipulating tooltips."
-	version = "1.0.0"
 	library = "gui"
 	moduleDependencies {
 		core {

--- a/library/item/build.gradle
+++ b/library/item/build.gradle
@@ -4,5 +4,4 @@ plugins {
 
 qslLibrary {
 	libraryName = "item"
-	version = "1.0.0"
 }

--- a/library/item/item_group/build.gradle
+++ b/library/item/item_group/build.gradle
@@ -9,7 +9,6 @@ qslModule {
 	description = "An API for adding Item Groups to Minecraft, allowing for custom icon display stacks, " +
 			"delayed icon registration, and adding custom stacks to the groups contents. " +
 			"This API also adds the GUI elements that allow for the multiple pages of item groups that can occur."
-	version = "1.0.0"
 	library = "item"
 	moduleDependencies {
 		core {

--- a/library/item/item_setting/build.gradle
+++ b/library/item/item_setting/build.gradle
@@ -7,7 +7,6 @@ qslModule {
 	moduleName = "item_setting"
 	id = "quilt_item_setting"
 	description = "An API for extended functionality in Item Settings"
-	version = "1.0.0"
 	library = "item"
 	moduleDependencies {
 		core {

--- a/library/worldgen/build.gradle
+++ b/library/worldgen/build.gradle
@@ -4,5 +4,4 @@ plugins {
 
 qslLibrary {
 	libraryName = "worldgen"
-	version = "1.0.0"
 }

--- a/library/worldgen/dimension/build.gradle
+++ b/library/worldgen/dimension/build.gradle
@@ -6,7 +6,6 @@ qslModule {
 	name = "Quilt Dimension API"
 	moduleName = "dimension"
 	id = "quilt_dimension"
-	version = "1.0.0"
 	library = "worldgen"
 	description = "An API for managing custom dimensions."
 	moduleDependencies {


### PR DESCRIPTION
This is just enough to be able to get out a release for `1.18`, and nothing more.

Modules and libraries use the same version as QSL as a whole, because module versioning is Really Hard to do properly, and we couldn't identify a major benefit for it.

This PR will be merged once both Oro and Aurora approve, and Quilted Fabric API's QL port is merged.