### PR TITLE
Fix issues with the recipe API.

### DIFF
--- a/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/api/BaseRecipeHandler.java
+++ b/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/api/BaseRecipeHandler.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.recipe.api;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeType;
+import net.minecraft.util.Identifier;
+
+/**
+ * Represents common recipe handler methods.
+ */
+@ApiStatus.NonExtendable
+public interface BaseRecipeHandler {
+	/**
+	 * Returns the recipe type of the specified recipe.
+	 *
+	 * @param id the identifier of the recipe
+	 * @return the recipe type if the recipe is present, else {@code null}
+	 */
+	@Nullable RecipeType<?> getTypeOf(Identifier id);
+
+	/**
+	 * Returns whether the {@link net.minecraft.recipe.RecipeManager} contains the specified recipe.
+	 *
+	 * @param id the identifier of the recipe
+	 * @return {@code true} if the recipe is present in the {@link net.minecraft.recipe.RecipeManager}, else {@code false}
+	 */
+	boolean contains(Identifier id);
+
+	/**
+	 * Returns whether the {@link net.minecraft.recipe.RecipeManager} contains the specified recipe of the specified recipe type.
+	 *
+	 * @param id   the identifier of the recipe
+	 * @param type the type of the recipe
+	 * @return {@code true} if the recipe is present in the {@link net.minecraft.recipe.RecipeManager}, else {@code false}
+	 */
+	boolean contains(Identifier id, RecipeType<?> type);
+
+	/**
+	 * Returns the recipe in {@link net.minecraft.recipe.RecipeManager} from its identifier.
+	 *
+	 * @param id the identifier of the recipe
+	 * @return the recipe if present, else {@code null}
+	 */
+	@Nullable Recipe<?> getRecipe(Identifier id);
+
+	/**
+	 * Returns the recipe of the specified recipe type in {@link net.minecraft.recipe.RecipeManager} from its identifier.
+	 *
+	 * @param id   the identifier of the recipe
+	 * @param type the type of the recipe
+	 * @param <T>  the type of the recipe
+	 * @return the recipe if present and of the correct type, else {@code null}
+	 */
+	@Nullable <T extends Recipe<?>> T getRecipe(Identifier id, RecipeType<T> type);
+
+	/**
+	 * Returns all registered recipes.
+	 *
+	 * @return a view of the registered recipes
+	 */
+	Map<RecipeType<?>, Map<Identifier, Recipe<?>>> getRecipes();
+
+	/**
+	 * Returns all registered recipes of the specified type.
+	 *
+	 * @param type the recipe type
+	 * @param <T>  the type of the recipe
+	 * @return a view of all the registered recipes of the specified type
+	 */
+	<T extends Recipe<?>> Collection<T> getRecipesOfType(RecipeType<T> type);
+}

--- a/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/api/RecipeLoadingEvents.java
+++ b/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/api/RecipeLoadingEvents.java
@@ -16,13 +16,10 @@
 
 package org.quiltmc.qsl.recipe.api;
 
-import java.util.Collection;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.recipe.Recipe;
 import net.minecraft.recipe.RecipeType;
@@ -129,72 +126,13 @@ public final class RecipeLoadingEvents {
 		 * This interface should not be extended by users.
 		 */
 		@ApiStatus.NonExtendable
-		interface RecipeHandler {
+		interface RecipeHandler extends BaseRecipeHandler {
 			/**
 			 * Replaces a recipe in the {@link net.minecraft.recipe.RecipeManager}.
 			 *
 			 * @param recipe the recipe
 			 */
 			void replace(Recipe<?> recipe);
-
-			/**
-			 * Returns the recipe type of the specified recipe.
-			 *
-			 * @param id the identifier of the recipe
-			 * @return the recipe type if the recipe is present, else {@code null}
-			 */
-			@Nullable RecipeType<?> getTypeOf(Identifier id);
-
-			/**
-			 * Returns whether the {@link net.minecraft.recipe.RecipeManager} contains the specified recipe.
-			 *
-			 * @param id the identifier of the recipe
-			 * @return {@code true} if the recipe is present in the {@link net.minecraft.recipe.RecipeManager}, else {@code false}
-			 */
-			boolean contains(Identifier id);
-
-			/**
-			 * Returns whether the {@link net.minecraft.recipe.RecipeManager} contains the specified recipe of the specified recipe type.
-			 *
-			 * @param id   the identifier of the recipe
-			 * @param type the type of the recipe
-			 * @return {@code true} if the recipe is present in the {@link net.minecraft.recipe.RecipeManager}, else {@code false}
-			 */
-			boolean contains(Identifier id, RecipeType<?> type);
-
-			/**
-			 * Returns the recipe in {@link net.minecraft.recipe.RecipeManager} from its identifier.
-			 *
-			 * @param id the identifier of the recipe
-			 * @return the recipe if present, else {@code null}
-			 */
-			@Nullable Recipe<?> getRecipe(Identifier id);
-
-			/**
-			 * Returns the recipe of the specified recipe type in {@link net.minecraft.recipe.RecipeManager} from its identifier.
-			 *
-			 * @param id   the identifier of the recipe
-			 * @param type the type of the recipe
-			 * @param <T>  the type of the recipe
-			 * @return the recipe if present and of the correct type, else {@code null}
-			 */
-			@Nullable <T extends Recipe<?>> T getRecipe(Identifier id, RecipeType<T> type);
-
-			/**
-			 * Returns all registered recipes.
-			 *
-			 * @return the registered recipes
-			 */
-			Map<RecipeType<?>, Map<Identifier, Recipe<?>>> getRecipes();
-
-			/**
-			 * Returns all registered recipes of the specified type.
-			 *
-			 * @param type the recipe type
-			 * @param <T>  the type of the recipe
-			 * @return all registered recipes of the specified type
-			 */
-			<T extends Recipe<?>> Collection<T> getRecipesOfType(RecipeType<T> type);
 		}
 	}
 
@@ -214,7 +152,7 @@ public final class RecipeLoadingEvents {
 		 * This interface should not be extended by users.
 		 */
 		@ApiStatus.NonExtendable
-		interface RecipeHandler {
+		interface RecipeHandler extends BaseRecipeHandler {
 			/**
 			 * Removes a recipe in the {@link net.minecraft.recipe.RecipeManager}.
 			 *
@@ -237,65 +175,6 @@ public final class RecipeLoadingEvents {
 			 * @param recipeRemovalPredicate the recipe removal predicate
 			 */
 			void removeIf(Predicate<Recipe<?>> recipeRemovalPredicate);
-
-			/**
-			 * Returns the recipe type of the specified recipe.
-			 *
-			 * @param id the identifier of the recipe
-			 * @return the recipe type if the recipe is present, else {@code null}
-			 */
-			@Nullable RecipeType<?> getTypeOf(Identifier id);
-
-			/**
-			 * Returns whether the {@link net.minecraft.recipe.RecipeManager} contains the specified recipe.
-			 *
-			 * @param id the identifier of the recipe
-			 * @return {@code true} if the recipe is present in the {@link net.minecraft.recipe.RecipeManager}, else {@code false}
-			 */
-			boolean contains(Identifier id);
-
-			/**
-			 * Returns whether the {@link net.minecraft.recipe.RecipeManager} contains the specified recipe of the specified recipe type.
-			 *
-			 * @param id   the identifier of the recipe
-			 * @param type the type of the recipe
-			 * @return {@code true} if the recipe is present in the {@link net.minecraft.recipe.RecipeManager}, else {@code false}
-			 */
-			boolean contains(Identifier id, RecipeType<?> type);
-
-			/**
-			 * Returns the recipe in {@link net.minecraft.recipe.RecipeManager} from its identifier.
-			 *
-			 * @param id the identifier of the recipe
-			 * @return the recipe if present, else {@code null}
-			 */
-			@Nullable Recipe<?> getRecipe(Identifier id);
-
-			/**
-			 * Returns the recipe of the specified recipe type in {@link net.minecraft.recipe.RecipeManager} from its identifier.
-			 *
-			 * @param id   the identifier of the recipe
-			 * @param type the type of the recipe
-			 * @param <T>  the type of the recipe
-			 * @return the recipe if present and of the correct type, else {@code null}
-			 */
-			@Nullable <T extends Recipe<?>> T getRecipe(Identifier id, RecipeType<T> type);
-
-			/**
-			 * Returns all registered recipes.
-			 *
-			 * @return the registered recipes
-			 */
-			Map<RecipeType<?>, Map<Identifier, Recipe<?>>> getRecipes();
-
-			/**
-			 * Returns all registered recipes of the specified type.
-			 *
-			 * @param type the recipe type
-			 * @param <T>  the type of the recipe
-			 * @return all registered recipes of the specified type
-			 */
-			<T extends Recipe<?>> Collection<T> getRecipesOfType(RecipeType<T> type);
 		}
 	}
 }

--- a/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/api/builder/ShapedRecipeBuilder.java
+++ b/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/api/builder/ShapedRecipeBuilder.java
@@ -43,10 +43,11 @@ public class ShapedRecipeBuilder extends RecipeBuilder<ShapedRecipeBuilder, Shap
 	 * @param pattern the pattern of the shaped recipe. Each string in this array is a line of ingredients.
 	 *                A character represents an ingredient and space is no ingredient
 	 */
-	public ShapedRecipeBuilder(String[] pattern) {
+	public ShapedRecipeBuilder(String... pattern) {
 		this.pattern = pattern;
 		this.width = pattern[0].length();
 		this.height = pattern.length;
+		this.ingredients.put(' ', Ingredient.EMPTY); // By default, space is an empty ingredient.
 	}
 
 	/**

--- a/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/api/builder/VanillaRecipeBuilders.java
+++ b/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/api/builder/VanillaRecipeBuilders.java
@@ -17,27 +17,15 @@
 package org.quiltmc.qsl.recipe.api.builder;
 
 
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
-
 import it.unimi.dsi.fastutil.chars.Char2ObjectMap;
-import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.chars.CharArraySet;
 
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemConvertible;
 import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.BlastingRecipe;
 import net.minecraft.recipe.CampfireCookingRecipe;
 import net.minecraft.recipe.Ingredient;
-import net.minecraft.recipe.Recipe;
-import net.minecraft.recipe.ShapedRecipe;
-import net.minecraft.recipe.ShapelessRecipe;
 import net.minecraft.recipe.SmeltingRecipe;
 import net.minecraft.recipe.SmokingRecipe;
 import net.minecraft.recipe.StonecuttingRecipe;
-import net.minecraft.tag.TagKey;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.collection.DefaultedList;
 

--- a/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/api/builder/VanillaRecipeBuilders.java
+++ b/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/api/builder/VanillaRecipeBuilders.java
@@ -59,7 +59,7 @@ public final class VanillaRecipeBuilders {
 	 * @param pattern the pattern of the shaped crafting recipe
 	 * @return the builder
 	 */
-	public static ShapedRecipeBuilder shapedRecipe(String[] pattern) {
+	public static ShapedRecipeBuilder shapedRecipe(String... pattern) {
 		return new ShapedRecipeBuilder(pattern);
 	}
 

--- a/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/api/package-info.java
+++ b/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/api/package-info.java
@@ -24,4 +24,5 @@
  * </ul>
  * This API is <b>NOT</b> supposed to be used for known at compile-time data-generation, please use the appropriate tools instead.
  */
+
 package org.quiltmc.qsl.recipe.api;

--- a/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/impl/BasicRecipeHandlerImpl.java
+++ b/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/impl/BasicRecipeHandlerImpl.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.recipe.impl;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeManager;
+import net.minecraft.recipe.RecipeType;
+import net.minecraft.util.Identifier;
+
+import org.quiltmc.qsl.recipe.api.BaseRecipeHandler;
+
+class BasicRecipeHandlerImpl implements BaseRecipeHandler {
+	final RecipeManager recipeManager;
+	final Map<RecipeType<?>, Map<Identifier, Recipe<?>>> recipes;
+	final Map<Identifier, Recipe<?>> globalRecipes;
+
+	BasicRecipeHandlerImpl(RecipeManager recipeManager, Map<RecipeType<?>, Map<Identifier, Recipe<?>>> recipes,
+	                       Map<Identifier, Recipe<?>> globalRecipes) {
+		this.recipeManager = recipeManager;
+		this.recipes = recipes;
+		this.globalRecipes = globalRecipes;
+	}
+
+	@Override
+	public @Nullable RecipeType<?> getTypeOf(Identifier id) {
+		return this.recipes.entrySet().stream()
+				.filter(entry -> entry.getValue().containsKey(id))
+				.findFirst()
+				.map(Map.Entry::getKey)
+				.orElse(null);
+	}
+
+	@Override
+	public boolean contains(Identifier id) {
+		return this.globalRecipes.containsKey(id);
+	}
+
+	@Override
+	public boolean contains(Identifier id, RecipeType<?> type) {
+		Map<Identifier, Recipe<?>> recipes = this.recipes.get(type);
+
+		if (recipes == null) return false;
+
+		return recipes.containsKey(id);
+	}
+
+	@Override
+	public @Nullable Recipe<?> getRecipe(Identifier id) {
+		return this.globalRecipes.get(id);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T extends Recipe<?>> @Nullable T getRecipe(Identifier id, RecipeType<T> type) {
+		Map<Identifier, Recipe<?>> recipes = this.recipes.get(type);
+
+		if (recipes == null) return null;
+
+		return (T) recipes.get(id);
+	}
+
+	@Override
+	public Map<RecipeType<?>, Map<Identifier, Recipe<?>>> getRecipes() {
+		return Collections.unmodifiableMap(this.recipes);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T extends Recipe<?>> Collection<T> getRecipesOfType(RecipeType<T> type) {
+		Map<Identifier, Recipe<?>> recipes = this.recipes.get(type);
+
+		if (recipes == null) {
+			return Collections.emptyList();
+		}
+
+		return Collections.unmodifiableCollection((Collection<T>) recipes.values());
+	}
+}

--- a/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/impl/ModifyRecipeHandlerImpl.java
+++ b/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/impl/ModifyRecipeHandlerImpl.java
@@ -16,12 +16,9 @@
 
 package org.quiltmc.qsl.recipe.impl;
 
-import java.util.Collection;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.recipe.Recipe;
 import net.minecraft.recipe.RecipeManager;
@@ -31,14 +28,12 @@ import net.minecraft.util.Identifier;
 import org.quiltmc.qsl.recipe.api.RecipeLoadingEvents;
 
 @ApiStatus.Internal
-final class ModifyRecipeHandlerImpl implements RecipeLoadingEvents.ModifyRecipesCallback.RecipeHandler {
-	final RecipeManager recipeManager;
-	final Map<RecipeType<?>, Map<Identifier, Recipe<?>>> recipes;
+final class ModifyRecipeHandlerImpl extends BasicRecipeHandlerImpl implements RecipeLoadingEvents.ModifyRecipesCallback.RecipeHandler {
 	int counter = 0;
 
-	ModifyRecipeHandlerImpl(RecipeManager recipeManager, Map<RecipeType<?>, Map<Identifier, Recipe<?>>> recipes) {
-		this.recipeManager = recipeManager;
-		this.recipes = recipes;
+	ModifyRecipeHandlerImpl(RecipeManager recipeManager, Map<RecipeType<?>, Map<Identifier, Recipe<?>>> recipes,
+	                        Map<Identifier, Recipe<?>> globalRecipes) {
+		super(recipeManager, recipes, globalRecipes);
 	}
 
 	private void add(Recipe<?> recipe) {
@@ -50,6 +45,7 @@ final class ModifyRecipeHandlerImpl implements RecipeLoadingEvents.ModifyRecipes
 		}
 
 		type.put(recipe.getId(), recipe);
+		this.globalRecipes.put(recipe.getId(), recipe);
 	}
 
 	@Override
@@ -68,6 +64,7 @@ final class ModifyRecipeHandlerImpl implements RecipeLoadingEvents.ModifyRecipes
 			}
 
 			this.recipes.get(oldType).put(recipe.getId(), recipe);
+			this.globalRecipes.put(recipe.getId(), recipe);
 		} else {
 			if (RecipeManagerImpl.DEBUG_MODE) {
 				RecipeManagerImpl.LOGGER.info("Replace new recipe {} with type {} (and old type {}) in modify phase.",
@@ -79,74 +76,5 @@ final class ModifyRecipeHandlerImpl implements RecipeLoadingEvents.ModifyRecipes
 		}
 
 		this.counter++;
-	}
-
-	@Override
-	public @Nullable RecipeType<?> getTypeOf(Identifier id) {
-		return this.recipes.entrySet().stream()
-				.filter(entry -> entry.getValue().containsKey(id))
-				.findFirst()
-				.map(Map.Entry::getKey)
-				.orElse(null);
-	}
-
-	@Override
-	public boolean contains(Identifier id) {
-		for (var recipes : this.recipes.values()) {
-			if (recipes.containsKey(id)) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	@Override
-	public boolean contains(Identifier id, RecipeType<?> type) {
-		Map<Identifier, Recipe<?>> recipes = this.recipes.get(type);
-
-		if (recipes == null) return false;
-
-		return recipes.containsKey(id);
-	}
-
-	@Override
-	public @Nullable Recipe<?> getRecipe(Identifier id) {
-		for (var recipes : this.recipes.values()) {
-			Recipe<?> recipe = recipes.get(id);
-
-			if (recipe != null) {
-				return recipe;
-			}
-		}
-
-		return null;
-	}
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public <T extends Recipe<?>> @Nullable T getRecipe(Identifier id, RecipeType<T> type) {
-		Map<Identifier, Recipe<?>> recipes = this.recipes.get(type);
-
-		if (recipes == null) return null;
-
-		return (T) recipes.get(id);
-	}
-
-	@Override
-	public Map<RecipeType<?>, Map<Identifier, Recipe<?>>> getRecipes() {
-		return this.recipes;
-	}
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public <T extends Recipe<?>> Collection<T> getRecipesOfType(RecipeType<T> type) {
-		Map<Identifier, Recipe<?>> recipes = this.recipes.get(type);
-
-		if (recipes == null) {
-			return ImmutableList.of();
-		}
-
-		return (Collection<T>) recipes.values();
 	}
 }

--- a/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/impl/RegisterRecipeHandlerImpl.java
+++ b/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/impl/RegisterRecipeHandlerImpl.java
@@ -31,12 +31,15 @@ import org.quiltmc.qsl.recipe.api.RecipeLoadingEvents;
 final class RegisterRecipeHandlerImpl implements RecipeLoadingEvents.AddRecipesCallback.RecipeHandler {
 	private final Map<Identifier, JsonElement> resourceMap;
 	private final Map<RecipeType<?>, ImmutableMap.Builder<Identifier, Recipe<?>>> builderMap;
+	private final ImmutableMap.Builder<Identifier, Recipe<?>> globalRecipeMapBuilder;
 	int registered = 0;
 
 	RegisterRecipeHandlerImpl(Map<Identifier, JsonElement> resourceMap,
-									  Map<RecipeType<?>, ImmutableMap.Builder<Identifier, Recipe<?>>> builderMap) {
+	                          Map<RecipeType<?>, ImmutableMap.Builder<Identifier, Recipe<?>>> builderMap,
+	                          ImmutableMap.Builder<Identifier, Recipe<?>> globalRecipeMapBuilder) {
 		this.resourceMap = resourceMap;
 		this.builderMap = builderMap;
+		this.globalRecipeMapBuilder = globalRecipeMapBuilder;
 	}
 
 	void register(Recipe<?> recipe) {
@@ -44,6 +47,7 @@ final class RegisterRecipeHandlerImpl implements RecipeLoadingEvents.AddRecipesC
 			ImmutableMap.Builder<Identifier, Recipe<?>> recipeBuilder =
 					this.builderMap.computeIfAbsent(recipe.getType(), o -> ImmutableMap.builder());
 			recipeBuilder.put(recipe.getId(), recipe);
+			this.globalRecipeMapBuilder.put(recipe.getId(), recipe);
 			this.registered++;
 
 			if (RecipeManagerImpl.DEBUG_MODE) {

--- a/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/impl/RemoveRecipeHandlerImpl.java
+++ b/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/impl/RemoveRecipeHandlerImpl.java
@@ -16,13 +16,10 @@
 
 package org.quiltmc.qsl.recipe.impl;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import com.google.common.collect.ImmutableList;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.recipe.Recipe;
 import net.minecraft.recipe.RecipeManager;
@@ -32,14 +29,12 @@ import net.minecraft.util.Identifier;
 import org.quiltmc.qsl.recipe.api.RecipeLoadingEvents;
 
 @ApiStatus.Internal
-final class RemoveRecipeHandlerImpl implements RecipeLoadingEvents.RemoveRecipesCallback.RecipeHandler {
-	final RecipeManager recipeManager;
-	final Map<RecipeType<?>, Map<Identifier, Recipe<?>>> recipes;
+final class RemoveRecipeHandlerImpl extends BasicRecipeHandlerImpl implements RecipeLoadingEvents.RemoveRecipesCallback.RecipeHandler {
 	int counter = 0;
 
-	RemoveRecipeHandlerImpl(RecipeManager recipeManager, Map<RecipeType<?>, Map<Identifier, Recipe<?>>> recipes) {
-		this.recipeManager = recipeManager;
-		this.recipes = recipes;
+	RemoveRecipeHandlerImpl(RecipeManager recipeManager, Map<RecipeType<?>, Map<Identifier, Recipe<?>>> recipes,
+	                        Map<Identifier, Recipe<?>> globalRecipes) {
+		super(recipeManager, recipes, globalRecipes);
 	}
 
 	@Override
@@ -51,6 +46,8 @@ final class RemoveRecipeHandlerImpl implements RecipeLoadingEvents.RemoveRecipes
 		}
 
 		if (this.recipes.get(recipeType).remove(id) != null) {
+			this.globalRecipes.remove(id);
+
 			if (RecipeManagerImpl.DEBUG_MODE) {
 				RecipeManagerImpl.LOGGER.info("Remove recipe {} with type {} in removal phase.", id, recipeType);
 			}
@@ -72,7 +69,7 @@ final class RemoveRecipeHandlerImpl implements RecipeLoadingEvents.RemoveRecipes
 		}
 	}
 
-	protected <T extends Recipe<?>> void removeIf(Map<Identifier, T> recipeMap, Predicate<T> recipeRemovalPredicate) {
+	private <T extends Recipe<?>> void removeIf(Map<Identifier, T> recipeMap, Predicate<T> recipeRemovalPredicate) {
 		if (recipeMap == null) return;
 
 		var it = recipeMap.entrySet().iterator();
@@ -85,78 +82,10 @@ final class RemoveRecipeHandlerImpl implements RecipeLoadingEvents.RemoveRecipes
 					RecipeManagerImpl.LOGGER.info("Remove recipe {} with type {} in removal phase.", entry.getKey(), entry.getValue().getType());
 				}
 
+				this.globalRecipes.remove(entry.getKey());
 				it.remove();
 				this.counter++;
 			}
 		}
-	}
-
-	@Override
-	public @Nullable RecipeType<?> getTypeOf(Identifier id) {
-		return this.recipes.entrySet().stream()
-				.filter(entry -> entry.getValue().containsKey(id))
-				.findFirst()
-				.map(Map.Entry::getKey)
-				.orElse(null);
-	}
-
-	@Override
-	public boolean contains(Identifier id) {
-		for (var recipes : this.recipes.values()) {
-			if (recipes.containsKey(id)) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	@Override
-	public boolean contains(Identifier id, RecipeType<?> type) {
-		Map<Identifier, Recipe<?>> recipes = this.recipes.get(type);
-
-		if (recipes == null) return false;
-
-		return recipes.containsKey(id);
-	}
-
-	@Override
-	public @Nullable Recipe<?> getRecipe(Identifier id) {
-		for (var recipes : this.recipes.values()) {
-			Recipe<?> recipe = recipes.get(id);
-
-			if (recipe != null) {
-				return recipe;
-			}
-		}
-
-		return null;
-	}
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public <T extends Recipe<?>> @Nullable T getRecipe(Identifier id, RecipeType<T> type) {
-		Map<Identifier, Recipe<?>> recipes = this.recipes.get(type);
-
-		if (recipes == null) return null;
-
-		return (T) recipes.get(id);
-	}
-
-	@Override
-	public Map<RecipeType<?>, Map<Identifier, Recipe<?>>> getRecipes() {
-		return this.recipes;
-	}
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public <T extends Recipe<?>> Collection<T> getRecipesOfType(RecipeType<T> type) {
-		Map<Identifier, Recipe<?>> recipes = this.recipes.get(type);
-
-		if (recipes == null) {
-			return ImmutableList.of();
-		}
-
-		return (Collection<T>) recipes.values();
 	}
 }

--- a/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/impl/VanillaRecipeBuildersImpl.java
+++ b/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/impl/VanillaRecipeBuildersImpl.java
@@ -90,7 +90,7 @@ public final class VanillaRecipeBuildersImpl {
 	}
 
 	public static CampfireCookingRecipe campfireCookingRecipe(Identifier id, String group, Ingredient input,
-															  ItemStack output, float experience, int cookTime) {
+	                                                          ItemStack output, float experience, int cookTime) {
 		if (input == Ingredient.EMPTY) throw new IllegalArgumentException("Input cannot be empty.");
 		if (cookTime < 0) throw new IllegalArgumentException("Cook time must be equal or greater than 0");
 

--- a/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/mixin/RecipeManagerMixin.java
+++ b/library/data/recipe/src/main/java/org/quiltmc/qsl/recipe/mixin/RecipeManagerMixin.java
@@ -16,6 +16,7 @@
 
 package org.quiltmc.qsl.recipe.mixin;
 
+import java.util.Collections;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
@@ -25,6 +26,7 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
@@ -43,14 +45,19 @@ public class RecipeManagerMixin {
 	@Shadow
 	private Map<RecipeType<?>, Map<Identifier, Recipe<?>>> recipes;
 
+	@Shadow
+	private Map<Identifier, Recipe<?>> field_36308;
+
 	@Inject(
 			method = "apply",
-			at = @At(value = "INVOKE", target = "Ljava/util/Map;entrySet()Ljava/util/Set;", ordinal = 1),
+			at = @At(value = "INVOKE", target = "Ljava/util/Map;entrySet()Ljava/util/Set;", remap = false, ordinal = 0),
 			locals = LocalCapture.CAPTURE_FAILHARD
 	)
 	private void onReload(Map<Identifier, JsonElement> map, ResourceManager resourceManager, Profiler profiler,
-	                      CallbackInfo ci, Map<RecipeType<?>, ImmutableMap.Builder<Identifier, Recipe<?>>> builderMap) {
-		RecipeManagerImpl.apply(map, builderMap);
+	                      CallbackInfo ci,
+	                      Map<RecipeType<?>, ImmutableMap.Builder<Identifier, Recipe<?>>> builderMap,
+	                      ImmutableMap.Builder<Identifier, Recipe<?>> globalRecipeMapBuilder) {
+		RecipeManagerImpl.apply(map, builderMap, globalRecipeMapBuilder);
 	}
 
 	/**
@@ -65,12 +72,31 @@ public class RecipeManagerMixin {
 		return ImmutableMapBuilderUtil.specialBuild(entry.getValue());
 	}
 
+	@Redirect(
+			method = "apply",
+			at = @At(
+					value = "INVOKE",
+					target = "Lcom/google/common/collect/ImmutableMap$Builder;build()Lcom/google/common/collect/ImmutableMap;",
+					remap = false
+			)
+	)
+	private ImmutableMap<Identifier, Recipe<?>> onCreateGlobalRecipeMap(ImmutableMap.Builder<Identifier, Recipe<?>> globalRecipeMapBuilder) {
+		return null; // The original method bounds us to return an immutable map, but we do not want that!
+	}
+
 	@Inject(
 			method = "apply",
-			at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;info(Ljava/lang/String;Ljava/lang/Object;)V", remap = false)
+			at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;info(Ljava/lang/String;Ljava/lang/Object;)V", remap = false),
+			locals = LocalCapture.CAPTURE_FAILHARD
 	)
 	private void onReloadEnd(Map<Identifier, JsonElement> map, ResourceManager resourceManager, Profiler profiler,
-	                         CallbackInfo ci) {
-		RecipeManagerImpl.applyModifications((RecipeManager) (Object) this, this.recipes);
+	                         CallbackInfo ci,
+	                         Map<RecipeType<?>, ImmutableMap.Builder<Identifier, Recipe<?>>> builderMap,
+	                         ImmutableMap.Builder<Identifier, Recipe<?>> globalRecipeMapBuilder) {
+		Map<Identifier, Recipe<?>> globalRecipes = ImmutableMapBuilderUtil.specialBuild(globalRecipeMapBuilder);
+
+		RecipeManagerImpl.applyModifications((RecipeManager) (Object) this, this.recipes, globalRecipes);
+
+		this.field_36308 = Collections.unmodifiableMap(globalRecipes);
 	}
 }

--- a/library/data/recipe/src/testmod/java/org/quiltmc/qsl/recipe/test/RecipeTestMod.java
+++ b/library/data/recipe/src/testmod/java/org/quiltmc/qsl/recipe/test/RecipeTestMod.java
@@ -55,7 +55,7 @@ public class RecipeTestMod implements ModInitializer {
 
 		RecipeManagerHelper.addRecipes(handler -> {
 			handler.register(new Identifier(NAMESPACE, "test2"),
-					id -> VanillaRecipeBuilders.shapedRecipe(new String[] {"IG", "C#"})
+					id -> VanillaRecipeBuilders.shapedRecipe("IG", "C#")
 							.ingredient('I', Items.IRON_INGOT)
 							.ingredient('G', Items.GOLD_INGOT)
 							.ingredient('C', Items.COAL)
@@ -68,7 +68,7 @@ public class RecipeTestMod implements ModInitializer {
 			handler.replace(VanillaRecipeBuilders.shapelessRecipe(new ItemStack(Items.NETHER_STAR))
 					.ingredient(Items.ACACIA_PLANKS)
 					.build(new Identifier("acacia_button"), ""));
-			handler.replace(VanillaRecipeBuilders.shapedRecipe(new String[] {"A", "C"})
+			handler.replace(VanillaRecipeBuilders.shapedRecipe("A", "C")
 					.ingredient('A', ItemTags.PLANKS)
 					.ingredient('C', Items.COAL)
 					.output(new ItemStack(Items.NETHER_BRICK))


### PR DESCRIPTION
After playing a bit with the recipe API in production, I noticed a severe issue: the recipe maps were not modified correctly.

Turns out there's **another** field which is a direct map from identifiers to recipes, and this one wasn't modified, causing log spam on join after using injected recipes from this.

So, this PR fixes this issue, and refactors a bunch of stuff to avoid duplicated code while preserving API.
I also made some methods that return maps to return unmodifiable views to avoid dangerous modifications.