### PR TITLE
Create a fat, remapped testmod jar

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,16 @@ jobs:
       - run: ./gradlew check build publishToMavenLocal --stacktrace --parallel
       - run: mkdir run && echo "eula=true" >> run/eula.txt
       - run: ./gradlew :runAutoTestServer --stacktrace
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
-          name: Artifacts
-          path: ./**/build/libs/
-      - uses: actions/upload-artifact@v2
+          name: Production Mods
+          path: |
+            ./**/build/libs/
+            !./build-logic/**
+            !./**/build/libs/*-javadoc.jar
+            !./**/build/libs/*-sources.jar
+            !./**/build/libs/*-testmod.jar
+      - uses: actions/upload-artifact@v3
         with:
-          name: Test Mod
-          path: ./**/build/libs/qsl-**-testmod.jar
+          name: Test Mods
+          path: ./**/build/libs/*-testmod.jar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: Artifacts
-          path: ./*/build/libs/
+          path: ./**/build/libs/
       - uses: actions/upload-artifact@v2
         with:
           name: Test Mod
-          path: ./build/libs/qsl-**-testmod.jar
+          path: ./**/build/libs/qsl-**-testmod.jar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,7 @@ jobs:
         with:
           name: Artifacts
           path: ./*/build/libs/
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Test Mod
+          path: ./build/libs/qsl-**-testmod.jar

--- a/build-logic/src/main/groovy/qsl.common.gradle
+++ b/build-logic/src/main/groovy/qsl.common.gradle
@@ -54,25 +54,30 @@ tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
 	it.options.release.set(Versions.JAVA_VERSION)
 }
+
 sourceSets {
 	testmod
 }
+
 task testmodJar(type: Jar) {
 	from sourceSets.testmod.output
 	archiveClassifier = "testmod-dev"
 	destinationDirectory = project.file("build/devlibs")
 }
+
 task testmodRemapJar(type: RemapJarTask, dependsOn: testmodJar) {
 	inputFile = testmodJar.archiveFile
 	classpath.from sourceSets.testmod.compileClasspath
 	archiveClassifier = "testmod"
 }
 build.dependsOn testmodRemapJar
+
 loom {
 	// Upstream Loom breaks this so we can't have nice things until the quilt-gradle replacement
 	//shareRemapCaches = true
 	// Enable runtime only log4j, forces mods to use SLF4J for logging.
 	runtimeOnlyLog4j = true
+
 	mixin {
 		add(sourceSets.main, project.name + ".refmap.json")
 		add(sourceSets.testmod, project.name + '_testmod.refmap.json')

--- a/build-logic/src/main/groovy/qsl.common.gradle
+++ b/build-logic/src/main/groovy/qsl.common.gradle
@@ -2,6 +2,8 @@
  * Common buildscript for QSL in projects which depend on Minecraft, whether for the API or for running the game.
  */
 
+
+import net.fabricmc.loom.task.RemapJarTask
 import qsl.internal.Versions;
 
 plugins {
@@ -52,10 +54,27 @@ tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
 	it.options.release.set(Versions.JAVA_VERSION)
 }
-
+sourceSets {
+	testmod
+}
+task testmodJar(type: Jar) {
+	from sourceSets.testmod.output
+	archiveClassifier = "testmod-dev"
+	destinationDirectory = project.file("build/devlibs")
+}
+task testmodRemapJar(type: RemapJarTask, dependsOn: testmodJar) {
+	inputFile = testmodJar.archiveFile
+	classpath.from sourceSets.testmod.compileClasspath
+	archiveClassifier = "testmod"
+}
+build.dependsOn testmodRemapJar
 loom {
 	// Upstream Loom breaks this so we can't have nice things until the quilt-gradle replacement
 	//shareRemapCaches = true
 	// Enable runtime only log4j, forces mods to use SLF4J for logging.
 	runtimeOnlyLog4j = true
+	mixin {
+		add(sourceSets.main, project.name + ".refmap.json")
+		add(sourceSets.testmod, project.name + '_testmod.refmap.json')
+	}
 }

--- a/build-logic/src/main/groovy/qsl.library.gradle
+++ b/build-logic/src/main/groovy/qsl.library.gradle
@@ -124,6 +124,7 @@ project.getTasksByName("checkModuleVersion", true).each {
 rootProject.afterEvaluate {
 	testmodRemapJar { tsk ->
 		nestedJars.setFrom(Collections.emptySet())
+
 		rootProject.subprojects.stream().filter {
 			it.path.startsWith(":${extension.libraryName.get()}:")
 		}.forEach {

--- a/build-logic/src/main/groovy/qsl.library.gradle
+++ b/build-logic/src/main/groovy/qsl.library.gradle
@@ -120,3 +120,15 @@ remapJar {
 project.getTasksByName("checkModuleVersion", true).each {
 	checkLibVersion.mustRunAfter it
 }
+
+rootProject.afterEvaluate {
+	testmodRemapJar { tsk ->
+		nestedJars.setFrom(Collections.emptySet())
+		rootProject.subprojects.stream().filter {
+			it.path.startsWith(":${extension.libraryName.get()}:")
+		}.forEach {
+			tsk.nestedJars.from it.tasks.getByName("remapJar")
+			tsk.nestedJars.from it.tasks.getByName("testmodRemapJar")
+		}
+	}
+}

--- a/build-logic/src/main/groovy/qsl.module.gradle
+++ b/build-logic/src/main/groovy/qsl.module.gradle
@@ -12,12 +12,13 @@
  * `gradle LIBRARY_NAME:MODULE_NAME:TASK_NAME`.
  */
 
+
 import qsl.internal.Git
-import qsl.internal.GroovyXml
 import qsl.internal.Versions
 import qsl.internal.extension.QslModuleExtension
 import qsl.internal.extension.QslModuleExtensionImpl
-import qsl.internal.dependency.QslLibraryDependency
+
+import java.nio.file.Files
 
 plugins {
 	id("java-library")
@@ -102,7 +103,20 @@ sourceSets {
 		runtimeClasspath += sourceSets.main.runtimeClasspath
 	}
 }
-
+processTestmodResources {
+	filesMatching("quilt.mod.json") {
+		boolean found = false
+		Files.readAllLines(it.file.toPath()).stream().forEach {
+			// Look for load_type of "always"
+			if (it.contains("\"load_type\": \"always\"")) {
+				found = true
+			}
+		}
+		if (!found) {
+			throw new GradleException("Testmod resource $it does not contain a load_type of \"always\"")
+		}
+	}
+}
 dependencies {
 	// testmod sourceSet should depend on everything in the main source set.
 	testmodImplementation sourceSets.main.output

--- a/build-logic/src/main/groovy/qsl.module.gradle
+++ b/build-logic/src/main/groovy/qsl.module.gradle
@@ -106,12 +106,14 @@ sourceSets {
 processTestmodResources {
 	filesMatching("quilt.mod.json") {
 		boolean found = false
+
 		Files.readAllLines(it.file.toPath()).stream().forEach {
 			// Look for load_type of "always"
 			if (it.contains("\"load_type\": \"always\"")) {
 				found = true
 			}
 		}
+
 		if (!found) {
 			throw new GradleException("Testmod resource $it does not contain a load_type of \"always\"")
 		}

--- a/build-logic/src/main/groovy/qsl.module.gradle
+++ b/build-logic/src/main/groovy/qsl.module.gradle
@@ -103,6 +103,7 @@ sourceSets {
 		runtimeClasspath += sourceSets.main.runtimeClasspath
 	}
 }
+
 processTestmodResources {
 	filesMatching("quilt.mod.json") {
 		boolean found = false
@@ -119,6 +120,7 @@ processTestmodResources {
 		}
 	}
 }
+
 dependencies {
 	// testmod sourceSet should depend on everything in the main source set.
 	testmodImplementation sourceSets.main.output

--- a/build-logic/src/main/java/qsl/internal/json/QmjBuilder.java
+++ b/build-logic/src/main/java/qsl/internal/json/QmjBuilder.java
@@ -34,8 +34,10 @@ public final class QmjBuilder {
 				.endObject() // contact -> metadata
 				.name("license").value("Apache-2.0")
 				.name("icon").value("assets/" + ext.getId().get() + "/icon.png")
-				.endObject(); // metadata -> quilt_loader
-		writer.name("intermediate_mappings").value("net.fabricmc:intermediary");
+				.endObject() // metadata -> quilt_loader
+				.name("intermediate_mappings").value("net.fabricmc:intermediary")
+				.name("load_type").value("if_possible");
+
 		writer.name("depends").beginArray();
 		writer.beginObject()
 				.name("id").value("quilt_loader")

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,6 @@ jar {
 	enabled = false
 }
 
-
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
@@ -121,6 +120,7 @@ afterEvaluate {
 
 	testmodRemapJar { tsk ->
 		nestedJars.setFrom(Collections.emptySet())
+
 		rootProject.subprojects.stream().filter {
 			it.path.count(':') == 1
 		}.forEach {

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ jar {
 	enabled = false
 }
 
+
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
@@ -115,6 +116,15 @@ afterEvaluate {
 					afterSync generateQmjForIdea
 				}
 			}
+		}
+	}
+
+	testmodRemapJar { tsk ->
+		nestedJars.setFrom(Collections.emptySet())
+		rootProject.subprojects.stream().filter {
+			it.path.count(':') == 1
+		}.forEach {
+			tsk.nestedJars.from it.tasks.getByName("testmodRemapJar")
 		}
 	}
 }

--- a/library/block/block_extensions/src/testmod/resources/quilt.mod.json
+++ b/library/block/block_extensions/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "init": [
         "org.quiltmc.qsl.block.extensions.test.Initializer"

--- a/library/block/src/testmod/resources/quilt.mod.json
+++ b/library/block/src/testmod/resources/quilt.mod.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "quilt_loader": {
+    "group": "org.quiltmc.qsl",
+    "id": "quilt_block_testmod",
+    "version": "1.0.0",
+    "metadata": {
+      "name": "Quilt Block Library Test Mod",
+      "license": "Apache-2.0"
+    },
+    "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always"
+  }
+}

--- a/library/core/crash_info/src/testmod/resources/quilt.mod.json
+++ b/library/core/crash_info/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "init": [
         "org.quiltmc.qsl.crash.test.CrashReportApiTestMod"

--- a/library/core/lifecycle_events/src/testmod/resources/quilt.mod.json
+++ b/library/core/lifecycle_events/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "init": [
         "org.quiltmc.qsl.lifecycle.test.event.ServerLifecycleTests::TESTS",

--- a/library/core/networking/src/testmod/resources/quilt.mod.json
+++ b/library/core/networking/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "init": [
         "org.quiltmc.qsl.networking.test.keybindreciever.NetworkingKeyBindPacketTest",

--- a/library/core/qsl_base/src/testmod/resources/quilt.mod.json
+++ b/library/core/qsl_base/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "init": [
         "org.quiltmc.qsl.base.test.QuiltBaseTestMod"

--- a/library/core/registry/src/testmod/resources/quilt.mod.json
+++ b/library/core/registry/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "init": [
         "org.quiltmc.qsl.registry.test.RegistryLibEventsTest",

--- a/library/core/resource_loader/src/testmod/resources/quilt.mod.json
+++ b/library/core/resource_loader/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "init": [
         "org.quiltmc.qsl.resource.loader.test.BuiltinResourcePackTestMod",

--- a/library/core/src/testmod/resources/quilt.mod.json
+++ b/library/core/src/testmod/resources/quilt.mod.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "quilt_loader": {
+    "group": "org.quiltmc.qsl",
+    "id": "quilt_core_testmod",
+    "version": "1.0.0",
+    "metadata": {
+      "name": "Quilt Core Library Test Mod",
+      "license": "Apache-2.0"
+    },
+    "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always"
+  }
+}

--- a/library/data/recipe/src/testmod/resources/quilt.mod.json
+++ b/library/data/recipe/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "init": [
         "org.quiltmc.qsl.recipe.test.RecipeTestMod"

--- a/library/data/registry_entry_attachments/src/testmod/resources/quilt.mod.json
+++ b/library/data/registry_entry_attachments/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "init": [
         "org.quiltmc.qsl.registry.attachment.test.SimpleAttachmentTest",

--- a/library/data/src/testmod/resources/quilt.mod.json
+++ b/library/data/src/testmod/resources/quilt.mod.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "quilt_loader": {
+    "group": "org.quiltmc.qsl",
+    "id": "quilt_data_testmod",
+    "version": "1.0.0",
+    "metadata": {
+      "name": "Quilt Data Library Test Mod",
+      "license": "Apache-2.0"
+    },
+    "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always"
+  }
+}

--- a/library/data/tags/src/testmod/resources/quilt.mod.json
+++ b/library/data/tags/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "events": [
         "org.quiltmc.qsl.tag.test.TagsTestMod"

--- a/library/gui/src/testmod/resources/quilt.mod.json
+++ b/library/gui/src/testmod/resources/quilt.mod.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "quilt_loader": {
+    "group": "org.quiltmc.qsl",
+    "id": "quilt_gui_testmod",
+    "version": "1.0.0",
+    "metadata": {
+      "name": "Quilt GUI Library Test Mod",
+      "license": "Apache-2.0"
+    },
+    "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always"
+  }
+}

--- a/library/gui/tooltip/src/testmod/resources/quilt.mod.json
+++ b/library/gui/tooltip/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "init": [
         "org.quiltmc.qsl.tooltip.test.TooltipTestMod"

--- a/library/item/item_group/src/testmod/resources/quilt.mod.json
+++ b/library/item/item_group/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "init": [
         "org.quiltmc.qsl.item.group.test.ItemGroupTest"

--- a/library/item/item_setting/src/testmod/resources/quilt.mod.json
+++ b/library/item/item_setting/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "init": [
         "org.quiltmc.qsl.item.test.QuiltItemSettingsTests",

--- a/library/item/src/testmod/resources/quilt.mod.json
+++ b/library/item/src/testmod/resources/quilt.mod.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "quilt_loader": {
+    "group": "org.quiltmc.qsl",
+    "id": "quilt_item_testmod",
+    "version": "1.0.0",
+    "metadata": {
+      "name": "Quilt Item Library Test Mod",
+      "license": "Apache-2.0"
+    },
+    "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always"
+  }
+}

--- a/library/management/client_command/src/testmod/resources/quilt.mod.json
+++ b/library/management/client_command/src/testmod/resources/quilt.mod.json
@@ -18,6 +18,7 @@
       }
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "client_events": [
         "org.quiltmc.qsl.command.client.test.ClientCommandApiTest"

--- a/library/management/command/src/testmod/resources/quilt.mod.json
+++ b/library/management/command/src/testmod/resources/quilt.mod.json
@@ -18,6 +18,7 @@
       }
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "events": [
         "org.quiltmc.qsl.command.test.CommandApiTest"

--- a/library/management/src/testmod/resources/quilt.mod.json
+++ b/library/management/src/testmod/resources/quilt.mod.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "quilt_loader": {
+    "group": "org.quiltmc.qsl",
+    "id": "quilt_management_testmod",
+    "version": "1.0.0",
+    "metadata": {
+      "name": "Quilt Management Library Test Mod",
+      "license": "Apache-2.0"
+    },
+    "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always"
+  }
+}

--- a/library/worldgen/dimension/src/testmod/resources/quilt.mod.json
+++ b/library/worldgen/dimension/src/testmod/resources/quilt.mod.json
@@ -9,6 +9,7 @@
       "license": "Apache-2.0"
     },
     "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
     "entrypoints": {
       "init": [
         "org.quiltmc.qsl.worldgen.dimension.QuiltDimensionTest"

--- a/library/worldgen/src/testmod/resources/quilt.mod.json
+++ b/library/worldgen/src/testmod/resources/quilt.mod.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "quilt_loader": {
+    "group": "org.quiltmc.qsl",
+    "id": "quilt_data_testmod",
+    "version": "1.0.0",
+    "metadata": {
+      "name": "Quilt Data Library Test Mod",
+      "license": "Apache-2.0"
+    },
+    "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always"
+  }
+}

--- a/src/testmod/resources/quilt.mod.json
+++ b/src/testmod/resources/quilt.mod.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "quilt_loader": {
+    "group": "org.quiltmc",
+    "id": "qsl_testmod",
+    "version": "1.0.0",
+    "metadata": {
+      "name": "Quilt Standard Libraries Test Mod",
+      "license": "Apache-2.0"
+    },
+    "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always"
+  }
+}


### PR DESCRIPTION
Remapped testmod jars that you can throw into your favorite launcher are created on the module, library, and root levels. They are not published to maven, but can be downloaded through Github Actions