### PR TITLE
Revert to class init, change to lambdas

### DIFF
--- a/library/block/block_extensions/src/main/java/org/quiltmc/qsl/block/extensions/mixin/client/RenderLayersMixin.java
+++ b/library/block/block_extensions/src/main/java/org/quiltmc/qsl/block/extensions/mixin/client/RenderLayersMixin.java
@@ -28,9 +28,6 @@ import net.minecraft.client.render.RenderLayers;
 import net.minecraft.fluid.Fluid;
 
 import org.quiltmc.qsl.block.extensions.impl.client.BlockRenderLayerMapImpl;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(RenderLayers.class)
 public abstract class RenderLayersMixin {
@@ -41,8 +38,10 @@ public abstract class RenderLayersMixin {
 	@Final
 	private static Map<Fluid, RenderLayer> FLUIDS;
 
-	@Inject(method = "<clinit>", at = @At("TAIL"))
-	private static void init(CallbackInfo ci) {
-		BlockRenderLayerMapImpl.initialize(BLOCKS::put, FLUIDS::put);
+	static {
+		BlockRenderLayerMapImpl.initialize(
+				(block, renderLayer) -> BLOCKS.put(block, renderLayer),
+				(fluid, renderLayer) -> FLUIDS.put(fluid, renderLayer)
+		);
 	}
 }


### PR DESCRIPTION
This mixin was recently hot fixed for compatibility with [Sodium](https://github.com/CaffeineMC/sodium-fabric). However, the solution simply moved the injection point behind Sodium, which also used a static initializer.

This proposed solution instead replaces the method references with lambdas. This ensures that the fields are accessed rather than the original objects. This way injection order doesn't matter, even if other mods change the maps after QSL.