### PR TITLE
Create CODEOWNERS, update PR Policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,15 @@
 # The core team takes responsibility for anything not delegated to a subteam
-* @qsl-core-library
+* @QuiltMC/qsl-core-library
 
 # Individual subteams. Teams with less than two members are "inactive" and commented out.
-# /library/block/ @qsl-block-library
-/library/core/ @qsl-core-library
-/library/data/ @qsl-data-library
-/library/entity/ @qsl-entity-library
-# /library/gui/ @qsl-gui-library
-# /library/item/ @qsl-item-library
-# /library/management/ @qsl-management-library
-# /library/other_content/ @qsl-other-content-library
-# /library/rendering/ @qsl-rendering-library
-# /library/transfer/ @qsl-transfer-library
-/library/worldgen/ @qsl-worldgen-library
+# /library/block/ @QuiltMC/qsl-block-library
+/library/core/ @QuiltMC/qsl-core-library
+/library/data/ @QuiltMC/qsl-data-library
+/library/entity/ @QuiltMC/qsl-entity-library
+# /library/gui/ @QuiltMC/qsl-gui-library
+# /library/item/ @QuiltMC/qsl-item-library
+# /library/management/ @QuiltMC/qsl-management-library
+# /library/other_content/ @QuiltMC/qsl-other-content-library
+# /library/rendering/ @QuiltMC/qsl-rendering-library
+# /library/transfer/ @QuiltMC/qsl-transfer-library
+/library/worldgen/ @QuiltMC/qsl-worldgen-library

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# The core team takes responsibility for anything not delegated to a subteam
+* @qsl-core-library
+
+# Individual subteams. Teams with less than two members are "inactive" and commented out.
+# /library/block/ @qsl-block-library
+/library/core/ @qsl-core-library
+/library/data/ @qsl-data-library
+/library/entity/ @qsl-entity-library
+# /library/gui/ @qsl-gui-library
+# /library/item/ @qsl-item-library
+# /library/management/ @qsl-management-library
+# /library/other_content/ @qsl-other-content-library
+# /library/rendering/ @qsl-rendering-library
+# /library/transfer/ @qsl-transfer-library
+/library/worldgen/ @qsl-worldgen-library

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Everything within this section is the definitions for the actual PR policy follo
 
 **Description**: Used for pull requests that make internal refactors and do not change any API, such as bugfixes or buildscript changes.
 
-**Required Approvals**: 1
+**Required Approvals**: 2
 - At least 1 approval must come directly from each library team whose code the pull request modifies.
 
 **Final Comment Period**: 3 days


### PR DESCRIPTION
This allows us to put all of our PR policy, except for Final Comment Periods, into the Github UI.