### PR TITLE
Quilt Biome API Mixin Fix + Minor QuiltBiomeTest tweaks

### DIFF
--- a/library/worldgen/biome/src/main/java/org/quiltmc/qsl/worldgen/biome/mixin/MultiNoiseBiomeSourceMixin.java
+++ b/library/worldgen/biome/src/main/java/org/quiltmc/qsl/worldgen/biome/mixin/MultiNoiseBiomeSourceMixin.java
@@ -40,7 +40,7 @@ import org.quiltmc.qsl.worldgen.biome.impl.NetherBiomeData;
 @Mixin(MultiNoiseBiomeSource.Preset.class)
 public class MultiNoiseBiomeSourceMixin {
 	// NOTE: This is a lambda-function in the NETHER preset field initializer
-	@Inject(method = "m_ixtcdgmf", at = @At("RETURN"), cancellable = true)
+	@Inject(method = "m_ixtcdgmf(Lnet/minecraft/util/registry/Registry;)Lnet/minecraft/world/biome/source/util/MultiNoiseUtil$ParameterRangeList;", at = @At("RETURN"), cancellable = true)
 	private static void appendNetherBiomes(Registry<Biome> registry, CallbackInfoReturnable<MultiNoiseUtil.ParameterRangeList<Holder<Biome>>> cir) {
 		MultiNoiseUtil.ParameterRangeList<Holder<Biome>> biomes = cir.getReturnValue();
 		List<Pair<MultiNoiseUtil.NoiseHypercube, Holder<Biome>>> entries = new ArrayList<>(biomes.getEntries());

--- a/library/worldgen/biome/src/testmod/java/org/quiltmc/qsl/worldgen/biome/QuiltBiomeTest.java
+++ b/library/worldgen/biome/src/testmod/java/org/quiltmc/qsl/worldgen/biome/QuiltBiomeTest.java
@@ -97,7 +97,7 @@ public class QuiltBiomeTest implements ModInitializer {
 
 		// The placement config is taken from the vanilla desert well, but no randomness
 		PlacedFeature PLACED_COMMON_DESERT_WELL = new PlacedFeature(featureEntry, List.of(InSquarePlacementModifier.getInstance(), PlacedFeatureUtil.MOTION_BLOCKING_HEIGHTMAP, BiomePlacementModifier.getInstance()));
-		Registry.register(BuiltinRegistries.PLACED_FEATURE, new Identifier(MOD_ID, "fab_desert_well"), PLACED_COMMON_DESERT_WELL);
+		Registry.register(BuiltinRegistries.PLACED_FEATURE, new Identifier(MOD_ID, "quilt_desert_well_placed"), PLACED_COMMON_DESERT_WELL);
 
 		BiomeModifications.create(new Identifier("quilt:testmod"))
 				.add(ModificationPhase.ADDITIONS,
@@ -109,7 +109,7 @@ public class QuiltBiomeTest implements ModInitializer {
 						context -> context.getGenerationSettings().addFeature(GenerationStep.Feature.TOP_LAYER_MODIFICATION,
 								BuiltinRegistries.PLACED_FEATURE.getKey(PLACED_COMMON_DESERT_WELL).orElseThrow()
 						))
-				//these three test should be glaringly obvious if they work or not, be sure to check forests as well
+				//it should be glaringly obvious if these three tests work or not; be sure to check forests as well
 				.add(ModificationPhase.ADDITIONS,
 						BiomeSelectors.foundInOverworld(),
 						context -> context.getEffects().setSkyColor(0x111111))


### PR DESCRIPTION
When trying to create a QFAPI bridge for Quilt Biome API, mixins were having issues with remapping. The full method descriptor is now being used to hopefully fix this issue. In addition, 2 very minor `QuiltBiomeTest` nitpicks were fixed - naming the tested desert well `quilt_desert_well_placed` instead of `fab_desert_well`, and rewriting one comment for clarity/grammatical correctness. This PR is needed in order to create a QFAPI bridge for Biome API.