### PR TITLE
Fix loading world generation objects from mods via JSON.

### DIFF
--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/DataPackLoadingContext.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/DataPackLoadingContext.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.resource.loader.impl;
+
+import com.google.gson.JsonElement;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.JsonOps;
+import com.mojang.serialization.Lifecycle;
+import org.jetbrains.annotations.ApiStatus;
+
+import net.minecraft.client.world.GeneratorTypes;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.registry.DynamicRegistryManager;
+import net.minecraft.util.registry.RegistryOps;
+import net.minecraft.world.gen.GeneratorOptions;
+
+@ApiStatus.Internal
+public record DataPackLoadingContext(DynamicRegistryManager.Writable registryManager,
+                                     ResourceManager resourceManager) {
+	/**
+	 * Loads the registries from the {@link #resourceManager() resource manager}.
+	 *
+	 * @return the dynamic ops
+	 */
+	public DynamicOps<JsonElement> loadRegistries() {
+		return RegistryOps.createAndLoad(JsonOps.INSTANCE, this.registryManager, this.resourceManager);
+	}
+
+	public DataResult<GeneratorOptions> loadGeneratorOptions(GeneratorOptions existing, DynamicOps<JsonElement> registryOps) {
+		DataResult<JsonElement> encodedBaseOptions = GeneratorOptions.CODEC.encodeStart(registryOps, existing)
+				.setLifecycle(Lifecycle.stable());
+		return encodedBaseOptions.flatMap(jsonElement -> GeneratorOptions.CODEC.parse(registryOps, jsonElement));
+	}
+
+	public DataResult<GeneratorOptions> loadDefaultGeneratorOptions(DynamicOps<JsonElement> registryOps) {
+		return this.loadGeneratorOptions(GeneratorTypes.create(this.registryManager), registryOps);
+	}
+}

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModResourcePackUtil.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModResourcePackUtil.java
@@ -18,6 +18,7 @@
 package org.quiltmc.qsl.resource.loader.impl;
 
 import java.io.InputStream;
+import java.util.ArrayList;
 
 import com.google.common.base.Charsets;
 import org.apache.commons.io.IOUtils;
@@ -25,11 +26,19 @@ import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.SharedConstants;
 import net.minecraft.resource.ResourceType;
+import net.minecraft.resource.pack.DataPackSettings;
+import net.minecraft.resource.pack.ResourcePack;
+import net.minecraft.resource.pack.ResourcePackProfile;
 
 import org.quiltmc.loader.api.ModMetadata;
 
 @ApiStatus.Internal
 public final class ModResourcePackUtil {
+	/**
+	 * Represents the default data-pack settings, including the default-enabled built-in data-packs.
+	 */
+	public static final DataPackSettings DEFAULT_SETTINGS = createDefaultDataPackSettings();
+
 	public static boolean containsDefault(ModMetadata info, String filename) {
 		return "pack.mcmeta".equals(filename);
 	}
@@ -59,5 +68,27 @@ public final class ModResourcePackUtil {
 		} else {
 			return "Quilt Mod \"" + info.id() + "\"";
 		}
+	}
+
+	private static DataPackSettings createDefaultDataPackSettings() {
+		var moddedResourcePacks = new ArrayList<ResourcePackProfile>();
+		ModResourcePackProvider.SERVER_RESOURCE_PACK_PROVIDER.register(moddedResourcePacks::add);
+
+		var enabled = new ArrayList<>(DataPackSettings.SAFE_MODE.getEnabled());
+		var disabled = new ArrayList<>(DataPackSettings.SAFE_MODE.getDisabled());
+
+		// This ensure that any built-in registered data packs by mods which needs to be enabled by default are
+		// as the data pack screen automatically put any data pack as disabled except the Default data pack.
+		for (var profile : moddedResourcePacks) {
+			ResourcePack pack = profile.createResourcePack();
+
+			if (pack.getActivationType().isEnabledByDefault()) {
+				enabled.add(profile.getName());
+			} else {
+				disabled.add(profile.getName());
+			}
+		}
+
+		return new DataPackSettings(enabled, disabled);
 	}
 }

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/TestServerMixin.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/TestServerMixin.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.resource.loader.mixin;
+
+import java.util.function.Supplier;
+
+import com.mojang.serialization.JsonOps;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.resource.pack.DataPackSettings;
+import net.minecraft.test.TestServer;
+import net.minecraft.util.registry.DynamicRegistryManager;
+import net.minecraft.util.registry.RegistryOps;
+
+import org.quiltmc.qsl.resource.loader.impl.ModResourcePackUtil;
+
+@Mixin(TestServer.class)
+public class TestServerMixin {
+	@ModifyArg(
+			method = "create",
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/unmapped/C_kjxfcecs$C_nrmvgbka;<init>(Lnet/minecraft/resource/pack/ResourcePackManager;Lnet/minecraft/resource/pack/DataPackSettings;Z)V"
+			),
+			index = 1
+	)
+	private static DataPackSettings replaceDefaultDataPackSettings(DataPackSettings initialDataPacks) {
+		return ModResourcePackUtil.DEFAULT_SETTINGS;
+	}
+
+	@Redirect(method = "method_40377", at = @At(value = "INVOKE", target = "Ljava/util/function/Supplier;get()Ljava/lang/Object;"))
+	private static Object loadRegistry(Supplier<Object> unused, ResourceManager resourceManager) {
+		DynamicRegistryManager.Writable registryManager = DynamicRegistryManager.builtInCopy();
+		// Force-loads the dynamic registry from data-packs as some mods may define dynamic game objects via data-driven capabilities.
+		RegistryOps.createAndLoad(JsonOps.INSTANCE, registryManager, resourceManager);
+		return registryManager.freeze();
+	}
+}

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/CreateWorldScreenMixin.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/client/CreateWorldScreenMixin.java
@@ -191,7 +191,7 @@ public abstract class CreateWorldScreenMixin {
 					if (frozenRegistryManager.get(Registry.WORLD_PRESET_WORLDGEN).size() == 0) {
 						throw new IllegalStateException("Needs at least one world preset to continue");
 					} else if (frozenRegistryManager.get(Registry.BIOME_KEY).size() == 0) {
-						throw new IllegalStateException("Needs at least one biome continue");
+						throw new IllegalStateException("Needs at least one biome to continue");
 					} else {
 						return Pair.of(Pair.of(generatorOptions, lifecycle), frozenRegistryManager);
 					}

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/server/MainMixin.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/server/MainMixin.java
@@ -16,20 +16,63 @@
 
 package org.quiltmc.qsl.resource.loader.mixin.server;
 
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.Lifecycle;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.resource.pack.DataPackSettings;
 import net.minecraft.server.Main;
 import net.minecraft.server.WorldStem;
+import net.minecraft.server.dedicated.ServerPropertiesLoader;
+import net.minecraft.util.Util;
+import net.minecraft.util.registry.DynamicRegistryManager;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.SaveProperties;
+import net.minecraft.world.gen.GeneratorOptions;
+import net.minecraft.world.level.LevelInfo;
+import net.minecraft.world.level.LevelProperties;
+import net.minecraft.world.level.storage.LevelStorage;
 
 import org.quiltmc.qsl.resource.loader.api.ResourceLoaderEvents;
+import org.quiltmc.qsl.resource.loader.impl.DataPackLoadingContext;
+import org.quiltmc.qsl.resource.loader.impl.ModResourcePackUtil;
 
 @Mixin(Main.class)
 public class MainMixin {
+	@Shadow
+	@Final
+	private static Logger LOGGER;
+
+	@ModifyArg(
+			method = "main",
+			at = @At(
+					value = "INVOKE",
+					target = "Ljava/util/Objects;requireNonNullElse(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+					remap = true
+			),
+			index = 1,
+			remap = false
+	)
+	private static Object replaceDefaultDataPackSettings(Object base) {
+		return ModResourcePackUtil.DEFAULT_SETTINGS;
+	}
+
 	@Inject(
 			method = "main",
 			at = @At(
@@ -61,5 +104,42 @@ public class MainMixin {
 	private static Throwable onFailedReloadResources(Throwable exception) {
 		ResourceLoaderEvents.END_DATA_PACK_RELOAD.invoker().onEndDataPackReload(null, null, exception);
 		return exception; // noop
+	}
+
+	@Inject(
+			method = "method_43613",
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/world/level/LevelProperties;<init>(Lnet/minecraft/world/level/LevelInfo;Lnet/minecraft/world/gen/GeneratorOptions;Lcom/mojang/serialization/Lifecycle;)V"
+			),
+			cancellable = true,
+			locals = LocalCapture.CAPTURE_FAILHARD
+	)
+	private static void onLoadDataPacks(LevelStorage.Session session, OptionSet optionSet, OptionSpec optionSpec,
+			ServerPropertiesLoader serverPropertiesLoader, OptionSpec optionSpec2,
+			ResourceManager resourceManager, DataPackSettings dataPackSettings,
+			CallbackInfoReturnable<Pair<SaveProperties, DynamicRegistryManager.Frozen>> cir,
+			DynamicRegistryManager.Writable writable,
+			DynamicOps<NbtElement> nbtRegistryOps,
+			SaveProperties saveProperties,
+			LevelInfo levelInfo,
+			GeneratorOptions existingGeneratorOptions) {
+		var dataPackLoadingContext = new DataPackLoadingContext(writable, resourceManager);
+		DataResult<GeneratorOptions> result = dataPackLoadingContext.loadGeneratorOptions(existingGeneratorOptions, dataPackLoadingContext.loadRegistries());
+
+		DynamicRegistryManager.Frozen frozenRegistryManager = dataPackLoadingContext.registryManager().freeze();
+		Lifecycle lifecycle = result.lifecycle().add(frozenRegistryManager.allElementsLifecycle());
+		GeneratorOptions generatorOptions = result.getOrThrow(
+				false, Util.addPrefix("Error parsing worldgen settings after loading data-packs: ", LOGGER::error)
+		);
+
+		if (frozenRegistryManager.get(Registry.WORLD_PRESET_WORLDGEN).size() == 0) {
+			throw new IllegalStateException("Needs at least one world preset to continue");
+		} else if (frozenRegistryManager.get(Registry.BIOME_KEY).size() == 0) {
+			throw new IllegalStateException("Needs at least one biome continue");
+		} else {
+			var levelProperties = new LevelProperties(levelInfo, generatorOptions, lifecycle);
+			cir.setReturnValue(Pair.of(levelProperties, frozenRegistryManager));
+		}
 	}
 }

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/server/MainMixin.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/server/MainMixin.java
@@ -136,7 +136,7 @@ public class MainMixin {
 		if (frozenRegistryManager.get(Registry.WORLD_PRESET_WORLDGEN).size() == 0) {
 			throw new IllegalStateException("Needs at least one world preset to continue");
 		} else if (frozenRegistryManager.get(Registry.BIOME_KEY).size() == 0) {
-			throw new IllegalStateException("Needs at least one biome continue");
+			throw new IllegalStateException("Needs at least one biome to continue");
 		} else {
 			var levelProperties = new LevelProperties(levelInfo, generatorOptions, lifecycle);
 			cir.setReturnValue(Pair.of(levelProperties, frozenRegistryManager));

--- a/library/core/resource_loader/src/main/resources/quilt_resource_loader.mixins.json
+++ b/library/core/resource_loader/src/main/resources/quilt_resource_loader.mixins.json
@@ -14,6 +14,7 @@
     "ReloadableResourceManagerMixin",
     "ResourcePackMixin",
     "ServerReloadableResourcesMixin",
+    "TestServerMixin",
     "VanillaDataPackProviderMixin",
     "server.MainMixin"
   ],

--- a/library/worldgen/dimension/src/main/java/org/quiltmc/qsl/worldgen/dimension/mixin/DimensionOptionsAccessor.java
+++ b/library/worldgen/dimension/src/main/java/org/quiltmc/qsl/worldgen/dimension/mixin/DimensionOptionsAccessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.worldgen.dimension.mixin;
+
+import java.util.Set;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.dimension.DimensionOptions;
+
+@Mixin(DimensionOptions.class)
+public interface DimensionOptionsAccessor {
+	@Accessor("BASE_DIMENSIONS")
+	static Set<RegistryKey<DimensionOptions>> getBaseDimensions() {
+		throw new IllegalStateException("Mixin injection failed.");
+	}
+}

--- a/library/worldgen/dimension/src/main/java/org/quiltmc/qsl/worldgen/dimension/mixin/LevelStorageBugfixMixin.java
+++ b/library/worldgen/dimension/src/main/java/org/quiltmc/qsl/worldgen/dimension/mixin/LevelStorageBugfixMixin.java
@@ -64,16 +64,16 @@ public class LevelStorageBugfixMixin {
 	 */
 	@Unique
 	private static void quilt$removeNonVanillaDimensionsFromNbt(NbtCompound worldGenSettings) {
-		var vanillaDimensionIds = new String[] {"minecraft:overworld", "minecraft:the_nether", "minecraft:the_end"};
-
 		NbtCompound dimensions = worldGenSettings.getCompound("dimensions");
 
-		if (dimensions.getSize() > vanillaDimensionIds.length) {
+		if (dimensions.getSize() > DimensionOptionsAccessor.getBaseDimensions().size()) {
 			var newDimensions = new NbtCompound();
 
-			for (var dimId : vanillaDimensionIds) {
-				if (dimensions.contains(dimId)) {
-					newDimensions.put(dimId, dimensions.getCompound(dimId));
+			for (var dimId : DimensionOptionsAccessor.getBaseDimensions()) {
+				var strId = dimId.getValue().toString();
+
+				if (dimensions.contains(strId)) {
+					newDimensions.put(strId, dimensions.getCompound(strId));
 				}
 			}
 

--- a/library/worldgen/dimension/src/main/resources/quilt_dimension.mixins.json
+++ b/library/worldgen/dimension/src/main/resources/quilt_dimension.mixins.json
@@ -3,6 +3,7 @@
   "package": "org.quiltmc.qsl.worldgen.dimension.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "DimensionOptionsAccessor",
     "EntityMixin",
     "LevelStorageBugfixMixin",
     "ServerPlayerEntityMixin"

--- a/library/worldgen/dimension/src/testmod/java/org/quiltmc/qsl/worldgen/dimension/EmptyChunkGenerator.java
+++ b/library/worldgen/dimension/src/testmod/java/org/quiltmc/qsl/worldgen/dimension/EmptyChunkGenerator.java
@@ -82,7 +82,7 @@ public class EmptyChunkGenerator extends ChunkGenerator {
 
 	@Override
 	public CompletableFuture<Chunk> populateNoise(Executor executor, Blender blender, RandomState randomState, StructureManager structureManager, Chunk chunk) {
-		return null;
+		return CompletableFuture.completedFuture(chunk);
 	}
 
 	@Override


### PR DESCRIPTION
tl;dr:
 - Fix Minecraft not loading dynamic registries from mods.
 - Fix Minecraft not loading custom dimensions at world creation.
 - The dimensions testmod finally run on a clean dedicated server.
 - Lot of patches.
 
This is rather urgent as it's breaking any worldgen mods that uses JSON.
Some of this stuff probably should get backported.

