### PR TITLE
Add mod resource packs caching for faster reloads.

### DIFF
--- a/codeformat/checkstyle.xml
+++ b/codeformat/checkstyle.xml
@@ -96,7 +96,7 @@
 
         <module name="Indentation">
             <property name="basicOffset" value="4"/>
-            <property name="caseIndent" value="0"/>
+            <property name="caseIndent" value="4"/>
             <property name="throwsIndent" value="4"/>
             <property name="arrayInitIndent" value="4"/>
             <property name="lineWrappingIndentation" value="8"/>

--- a/library/core/resource_loader/README.md
+++ b/library/core/resource_loader/README.md
@@ -5,5 +5,7 @@ and other resource-loading-related hooks.
 
 ## System properties
 
+- `quilt.resource_loader.disable_caching` (boolean)
+  Defines if the mod resource caching should be forced-disabled, default: `false`.
 - `quilt.resource_loader.experimental_screen_override` (boolean)
   Defines whether the experimental screen override is active or not, default: `true`.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/GroupResourcePack.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/GroupResourcePack.java
@@ -184,7 +184,7 @@ public abstract class GroupResourcePack implements ResourcePack {
 		 * @param type         the resource type of this resource pack
 		 * @param basePack     the base resource pack
 		 * @param packs        the additional packs
-		 * @param basePriority {@code true} if the base resource pack has priority over the additional packs, otherwise {@code false}.
+		 * @param basePriority {@code true} if the base resource pack has priority over the additional packs, or {@code false} otherwise.
 		 *                     Ignored if the base resource pack is already present in the list
 		 */
 		public Wrapped(ResourceType type, ResourcePack basePack, List<ResourcePack> packs, boolean basePriority) {

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/ResourceLoader.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/ResourceLoader.java
@@ -77,7 +77,7 @@ public interface ResourceLoader {
 	 *
 	 * @param id             the identifier of the resource pack; its namespace must be the same as the mod id
 	 * @param activationType the activation type of the resource pack
-	 * @return {@code true} if the resource pack was successfully registered, otherwise {@code false}
+	 * @return {@code true} if the resource pack was successfully registered, or {@code false} otherwise
 	 * @throws IllegalArgumentException if a mod with the corresponding namespace given in id cannot be found
 	 * @see #registerBuiltinResourcePack(Identifier, ResourcePackActivationType, Text)
 	 * @see #registerBuiltinResourcePack(Identifier, ModContainer, ResourcePackActivationType)
@@ -104,7 +104,7 @@ public interface ResourceLoader {
 	 * @param id             the identifier of the resource pack; its namespace must be the same as the mod id
 	 * @param activationType the activation type of the resource pack
 	 * @param displayName    the display name of the resource pack
-	 * @return {@code true} if the resource pack was successfully registered, otherwise {@code false}
+	 * @return {@code true} if the resource pack was successfully registered, or {@code false} otherwise
 	 * @throws IllegalArgumentException if a mod with the corresponding namespace given in id cannot be found
 	 * @see #registerBuiltinResourcePack(Identifier, ResourcePackActivationType)
 	 * @see #registerBuiltinResourcePack(Identifier, ModContainer, ResourcePackActivationType)
@@ -132,7 +132,7 @@ public interface ResourceLoader {
 	 * @param id             the identifier of the resource pack
 	 * @param container      the mod container
 	 * @param activationType the activation type of the resource pack
-	 * @return {@code true} if the resource pack was successfully registered, otherwise {@code false}
+	 * @return {@code true} if the resource pack was successfully registered, or {@code false} otherwise
 	 * @see #registerBuiltinResourcePack(Identifier, ResourcePackActivationType)
 	 * @see #registerBuiltinResourcePack(Identifier, ResourcePackActivationType, Text)
 	 * @see #registerBuiltinResourcePack(Identifier, ModContainer, ResourcePackActivationType, Text)
@@ -158,7 +158,7 @@ public interface ResourceLoader {
 	 * @param container      the mod container
 	 * @param activationType the activation type of the resource pack
 	 * @param displayName    the display name of the resource pack
-	 * @return {@code true} if the resource pack was successfully registered, otherwise {@code false}
+	 * @return {@code true} if the resource pack was successfully registered, or {@code false} otherwise
 	 * @see #registerBuiltinResourcePack(Identifier, ResourcePackActivationType)
 	 * @see #registerBuiltinResourcePack(Identifier, ResourcePackActivationType, Text)
 	 * @see #registerBuiltinResourcePack(Identifier, ModContainer, ResourcePackActivationType)

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/ResourceLoaderEvents.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/ResourceLoaderEvents.java
@@ -87,7 +87,7 @@ public final class ResourceLoaderEvents {
 		 *
 		 * @param server          the server, may be {@code null} for the first reload
 		 * @param resourceManager the resource manager, may be {@code null} if the data pack reload failed
-		 * @param error           present if the data pack reload failed, otherwise {@code null}
+		 * @param error           present if the data pack reload failed, or {@code null} otherwise
 		 */
 		void onEndDataPackReload(@Nullable MinecraftServer server, ResourceManager resourceManager, @Nullable Throwable error);
 	}

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/ResourcePackActivationType.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/ResourcePackActivationType.java
@@ -36,7 +36,7 @@ public enum ResourcePackActivationType {
 	/**
 	 * Returns whether this resource pack will be enabled by default or not.
 	 *
-	 * @return {@code true} if enabled by default, otherwise {@code false}
+	 * @return {@code true} if enabled by default, or {@code false} otherwise
 	 */
 	public boolean isEnabledByDefault() {
 		return this == DEFAULT_ENABLED || this == ALWAYS_ENABLED;

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/client/ClientResourceLoaderEvents.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/client/ClientResourceLoaderEvents.java
@@ -73,7 +73,7 @@ public final class ClientResourceLoaderEvents {
 		 *
 		 * @param client          the server
 		 * @param resourceManager the resource manager
-		 * @param first           {@code true} if it's the first resource reload, otherwise {@code false}
+		 * @param first           {@code true} if it's the first resource reload, or {@code false} otherwise
 		 */
 		void onStartResourcePackReload(MinecraftClient client, ResourceManager resourceManager, boolean first);
 	}
@@ -92,8 +92,8 @@ public final class ClientResourceLoaderEvents {
 		 *
 		 * @param client          the client
 		 * @param resourceManager the resource manager
-		 * @param first           {@code true} if it's the first resource reload, otherwise {@code false}
-		 * @param error           present if the resource pack reload failed, otherwise {@code null}
+		 * @param first           {@code true} if it's the first resource reload, or {@code false} otherwise
+		 * @param error           present if the resource pack reload failed, or {@code null} otherwise
 		 */
 		void onEndResourcePackReload(MinecraftClient client, ResourceManager resourceManager, boolean first,
 				@Nullable Throwable error);

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModFileOps.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModFileOps.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.resource.loader.impl;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import org.quiltmc.loader.api.ModMetadata;
+import org.quiltmc.qsl.resource.loader.impl.cache.EntryType;
+
+/**
+ * Represents a {@link File} implementation of {@link ModIoOps}.
+ *
+ * @author LambdAurora
+ */
+@ApiStatus.Internal
+final class ModFileOps extends ModIoOps {
+	ModFileOps(Path basePath, ModMetadata modInfo) {
+		super(basePath, modInfo);
+	}
+
+	@Override
+	public Path getPath(String path) {
+		var p = this.getNormalizedPath(path);
+
+		if (p.toFile().exists()) {
+			return p;
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public EntryType getEntryType(String path) {
+		return this.getEntryType(this.getNormalizedPath(path));
+	}
+
+	@Override
+	public EntryType getEntryType(Path path) {
+		File file = path.toFile();
+
+		if (file.isFile()) {
+			return EntryType.FILE;
+		} else if (file.isDirectory()) {
+			return EntryType.DIRECTORY;
+		} else {
+			return EntryType.EMPTY;
+		}
+	}
+}

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModIoOps.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModIoOps.java
@@ -50,7 +50,7 @@ public abstract class ModIoOps {
 	}
 
 	/**
-	 * {@return the normalized path to access this mod's resources if it exists, otherwise {@code null}}
+	 * {@return the normalized path to access this mod's resources if it exists, or {@code null} otherwise}
 	 *
 	 * @param path the Minecraft-formatted path
 	 */

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModIoOps.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModIoOps.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.resource.loader.impl;
+
+import java.nio.file.Path;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import org.quiltmc.loader.api.ModMetadata;
+import org.quiltmc.qsl.resource.loader.impl.cache.EntryType;
+
+/**
+ * Defines some I/O operations that may be needed to access a mod's resources.
+ *
+ * @author LambdAurora
+ */
+@ApiStatus.Internal
+public abstract class ModIoOps {
+	protected final Path basePath;
+	private final String separator;
+	private final ModMetadata modMetadata;
+
+	public ModIoOps(Path basePath, ModMetadata modMetadata) {
+		this.basePath = basePath;
+		this.separator = basePath.getFileSystem().getSeparator();
+		this.modMetadata = modMetadata;
+	}
+
+	/**
+	 * {@return the normalized path to access this mod's resources}
+	 *
+	 * @param path the Minecraft-formatted resource path
+	 */
+	public Path getNormalizedPath(String path) {
+		return this.basePath.resolve(path.replace("/", this.getSeparator())).toAbsolutePath().normalize();
+	}
+
+	/**
+	 * {@return the normalized path to access this mod's resources if it exists, otherwise {@code null}}
+	 *
+	 * @param path the Minecraft-formatted path
+	 */
+	public abstract Path getPath(String path);
+
+	public abstract EntryType getEntryType(String path);
+
+	public abstract EntryType getEntryType(Path path);
+
+	/**
+	 * {@return the path separator used for this mod}
+	 */
+	public String getSeparator() {
+		return this.separator;
+	}
+
+	/**
+	 * {@return the mod metadata}
+	 */
+	public ModMetadata getModMetadata() {
+		return this.modMetadata;
+	}
+}

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModNioOps.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModNioOps.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.resource.loader.impl;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import org.quiltmc.loader.api.ModMetadata;
+import org.quiltmc.qsl.resource.loader.impl.cache.EntryType;
+
+/**
+ * Represents a NIO implementation of {@link ModIoOps}.
+ *
+ * @author LambdAurora
+ */
+@ApiStatus.Internal
+final class ModNioOps extends ModIoOps {
+	ModNioOps(Path basePath, ModMetadata modInfo) {
+		super(basePath, modInfo);
+	}
+
+	@Override
+	public Path getPath(String path) {
+		Path childPath = this.getNormalizedPath(path);
+
+		if (childPath.startsWith(basePath) && Files.exists(childPath)) {
+			return childPath;
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public EntryType getEntryType(String path) {
+		return this.getEntryType(this.getNormalizedPath(path));
+	}
+
+	@Override
+	public EntryType getEntryType(Path path) {
+		if (path.startsWith(basePath)) {
+			try {
+				var attr = Files.readAttributes(path, BasicFileAttributes.class);
+
+				if (attr.isRegularFile()) {
+					return EntryType.FILE;
+				} else if (attr.isDirectory()) {
+					return EntryType.DIRECTORY;
+				}
+			} catch (IOException e) {
+				// Ignored
+			}
+		}
+
+		return EntryType.EMPTY;
+	}
+}

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ResourceLoaderImpl.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ResourceLoaderImpl.java
@@ -308,7 +308,7 @@ public final class ResourceLoaderImpl implements ResourceLoader {
 	 * @param container      the mod container
 	 * @param activationType the activation type of the resource pack
 	 * @param displayName    the display name of the resource pack
-	 * @return {@code true} if successfully registered the resource pack, else {@code false}
+	 * @return {@code true} if successfully registered the resource pack, or {@code false} otherwise
 	 * @see ResourceLoader#registerBuiltinResourcePack(Identifier, ModContainer, ResourcePackActivationType, Text)
 	 */
 	public static boolean registerBuiltinResourcePack(Identifier id, String subPath, ModContainer container,

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ResourceLoaderImpl.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ResourceLoaderImpl.java
@@ -35,6 +35,7 @@ import java.util.function.Consumer;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import net.fabricmc.api.EnvType;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
@@ -55,6 +56,7 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.ModMetadata;
 import org.quiltmc.loader.api.QuiltLoader;
 import org.quiltmc.loader.api.minecraft.MinecraftQuiltLoader;
 import org.quiltmc.qsl.resource.loader.api.GroupResourcePack;
@@ -69,6 +71,14 @@ import org.quiltmc.qsl.resource.loader.mixin.NamespaceResourceManagerAccessor;
 @ApiStatus.Internal
 public final class ResourceLoaderImpl implements ResourceLoader {
 	private static final Map<ResourceType, ResourceLoaderImpl> IMPL_MAP = new EnumMap<>(ResourceType.class);
+	/**
+	 * Represents a cache of the client mod resource packs so resource packs that can cache don't lose their cache.
+	 */
+	private static final Map<String, List<ModNioResourcePack>> CLIENT_MOD_RESOURCE_PACKS = new Object2ObjectOpenHashMap<>();
+	/**
+	 * Represents a cache of the server mod data packs so resource packs that can cache don't lose their cache.
+	 */
+	private static final Map<String, List<ModNioResourcePack>> SERVER_MOD_RESOURCE_PACKS = new Object2ObjectOpenHashMap<>();
 	private static final Map<String, ModNioResourcePack> CLIENT_BUILTIN_RESOURCE_PACKS = new Object2ObjectOpenHashMap<>();
 	private static final Map<String, ModNioResourcePack> SERVER_BUILTIN_RESOURCE_PACKS = new Object2ObjectOpenHashMap<>();
 	private static final Logger LOGGER = LoggerFactory.getLogger("ResourceLoader");
@@ -174,6 +184,7 @@ public final class ResourceLoaderImpl implements ResourceLoader {
 			// Locate MC jar by finding the URL that contains the assets root.
 			URL assetsRootUrl = DefaultResourcePack.class.getResource("/" + type.getDirectory() + "/.mcassetsroot");
 
+			//noinspection ConstantConditions
 			return Paths.get(assetsRootUrl.toURI()).resolve("../..").toAbsolutePath().normalize();
 		} catch (Exception exception) {
 			throw new RuntimeException("Quilt: Failed to locate Minecraft assets root!", exception);
@@ -199,8 +210,23 @@ public final class ResourceLoaderImpl implements ResourceLoader {
 	 * @param subPath the resource pack sub path directory in mods, may be {@code null}
 	 */
 	public static void appendModResourcePacks(List<ResourcePack> packs, ResourceType type, @Nullable String subPath) {
+		var modResourcePacks = type == ResourceType.CLIENT_RESOURCES
+				? CLIENT_MOD_RESOURCE_PACKS : SERVER_MOD_RESOURCE_PACKS;
+		var existingList = modResourcePacks.get(subPath);
+		var byMod = new Reference2ObjectOpenHashMap<ModMetadata, ModNioResourcePack>();
+
+		if (existingList != null) {
+			for (var pack : existingList) {
+				byMod.put(pack.modInfo, pack);
+			}
+		}
+
 		for (var container : QuiltLoader.getAllMods()) {
 			if (container.getSourceType() == ModContainer.BasicSourceType.BUILTIN) {
+				continue;
+			}
+
+			if (byMod.containsKey(container.metadata())) {
 				continue;
 			}
 
@@ -216,12 +242,17 @@ public final class ResourceLoaderImpl implements ResourceLoader {
 				path = childPath;
 			}
 
-			var pack = ModNioResourcePack.ofMod(container.metadata(), path, type, null);
-
-			if (!pack.getNamespaces(type).isEmpty()) {
-				packs.add(pack);
-			}
+			byMod.put(container.metadata(), ModNioResourcePack.ofMod(container.metadata(), path, type, null));
 		}
+
+		List<ModNioResourcePack> packList = byMod.values().stream()
+				.filter(pack -> !pack.getNamespaces(type).isEmpty())
+				.toList();
+
+		// Cache the pack list for the next reload.
+		modResourcePacks.put(subPath, packList);
+
+		packs.addAll(packList);
 	}
 
 	public static GroupResourcePack.Wrapped buildMinecraftResourcePack(DefaultResourcePack vanillaPack) {

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/CacheTree.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/CacheTree.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.resource.loader.impl.cache;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import org.quiltmc.qsl.resource.loader.impl.ModIoOps;
+
+/**
+ * Contains the definition of a tree structure for caching, each node represents either a directory, a file, or a missing entry.
+ * <p>
+ * This may be dangerous if someone does a lot of one-time access.
+ *
+ * @author LambdAurora
+ */
+@ApiStatus.Internal
+public final class CacheTree {
+	/**
+	 * {@return a new tree, represented as a root branch node}
+	 */
+	static Branch newTree() {
+		return new Branch(null, null);
+	}
+
+	/**
+	 * Represents a node of the tree.
+	 */
+	public abstract static class Node {
+		private final Branch parent;
+		private final String path;
+		private final EntryType type;
+
+		protected Node(Branch parent, String path, EntryType type) {
+			this.parent = parent;
+			this.path = path;
+			this.type = type;
+		}
+
+		public Branch getParent() {
+			return this.parent;
+		}
+
+		public boolean isRoot() {
+			return this.getParent() == null;
+		}
+
+		public String getPathPart() {
+			return this.path;
+		}
+
+		public String getFullPath() {
+			var list = new ArrayList<String>();
+			var elem = this;
+
+			while (!elem.isRoot()) {
+				list.add(0, elem.getPathPart());
+
+				elem = elem.getParent();
+			}
+
+			return String.join("/", list);
+		}
+
+		public EntryType getType() {
+			return this.type;
+		}
+
+		public @Nullable ResourceAccess.Entry toEntry(ModIoOps ops) {
+			if (this.type == EntryType.EMPTY) return null;
+
+			return new ResourceAccess.Entry(ops.getNormalizedPath(this.getFullPath()), this.type);
+		}
+	}
+
+	/**
+	 * Represents a branch of the tree.
+	 */
+	public static final class Branch extends Node {
+		private final Map<String, Node> nodes = new ConcurrentHashMap<>();
+
+		public Branch(Branch parent, String path) {
+			super(parent, path, EntryType.DIRECTORY);
+		}
+
+		public Branch putBranch(String name) {
+			var child = new Branch(this, name);
+			this.nodes.put(name, child);
+			return child;
+		}
+
+		public void putEmpty(String name) {
+			var child = new Leaf(this, name, EntryType.EMPTY);
+			this.nodes.put(name, child);
+		}
+
+		public Leaf putFile(String name) {
+			var child = new Leaf(this, name, EntryType.FILE);
+			this.nodes.put(name, child);
+			return child;
+		}
+
+		public @Nullable Node resolveOrCompute(ModIoOps io, String path) {
+			int firstSeparator = path.indexOf('/');
+			String childName = firstSeparator == -1 ? path : path.substring(0, firstSeparator);
+
+			Node node = this.nodes.get(childName);
+
+			if (node == null) {
+				String absolutePath = childName;
+
+				if (!this.isRoot()) {
+					absolutePath = this.getFullPath() + '/' + absolutePath;
+				}
+
+				var type = io.getEntryType(absolutePath);
+
+				switch (type) {
+					case EMPTY -> {
+						this.putEmpty(childName);
+						return null;
+					}
+					case DIRECTORY -> {
+						Branch branch = this.putBranch(childName);
+
+						if (firstSeparator != -1) {
+							return branch.resolveOrCompute(io, path.substring(firstSeparator + 1));
+						} else {
+							return branch;
+						}
+					}
+					case FILE -> {
+						Leaf leaf = this.putFile(childName);
+
+						if (firstSeparator == -1) {
+							return leaf;
+						}
+					}
+				}
+			} else {
+				if (node.getType() == EntryType.EMPTY) {
+					return null;
+				}
+
+				if (firstSeparator == -1) {
+					return node;
+				} else if (node instanceof Branch branch) {
+					return branch.resolveOrCompute(io, path.substring(firstSeparator + 1));
+				}
+			}
+
+			return null;
+		}
+	}
+
+	public static final class Leaf extends Node {
+		public Leaf(Branch parent, String path, EntryType type) {
+			super(parent, path, type);
+		}
+	}
+}

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/EntryType.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/EntryType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.resource.loader.impl.cache;
+
+import org.jetbrains.annotations.ApiStatus;
+
+@ApiStatus.Internal
+public enum EntryType {
+	EMPTY,
+	FILE,
+	DIRECTORY
+}

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/ResourceAccess.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/ResourceAccess.java
@@ -86,11 +86,7 @@ public class ResourceAccess {
 	public EntryType getEntryType(String pathName) {
 		var entry = this.getEntry(pathName);
 
-		if (entry == null) {
-			return EntryType.EMPTY;
-		} else {
-			return entry.type();
-		}
+		return entry != null ? entry.type() : EntryType.EMPTY;
 	}
 
 	/**

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/ResourceAccess.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/ResourceAccess.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.resource.loader.impl.cache;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.mojang.logging.LogUtils;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+
+import net.minecraft.resource.ResourceType;
+
+import org.quiltmc.qsl.resource.loader.impl.ModIoOps;
+import org.quiltmc.qsl.resource.loader.mixin.IdentifierAccessor;
+
+/**
+ * Represents a simple way to access resources, no caching is applied.
+ *
+ * @author LambdAurora
+ */
+@ApiStatus.Internal
+public class ResourceAccess {
+	protected static final Logger LOGGER = LogUtils.getLogger();
+	protected final ModIoOps io;
+
+	public ResourceAccess(ModIoOps io) {
+		this.io = io;
+	}
+
+	/**
+	 * Gets a resource entry from the given path.
+	 *
+	 * @param pathName the path of the resource
+	 * @return the resource entry if it exists, otherwise {@code null}
+	 */
+	public @Nullable Entry getEntry(String pathName) {
+		var path = this.io.getPath(pathName);
+
+		if (path == null) {
+			return null;
+		}
+
+		try {
+			var attributes = Files.readAttributes(path, BasicFileAttributes.class);
+
+			if (attributes.isRegularFile()) {
+				return new Entry(path, EntryType.FILE);
+			} else if (attributes.isDirectory()) {
+				return new Entry(path, EntryType.DIRECTORY);
+			}
+		} catch (IOException e) {
+			// ignored
+		}
+
+		return null;
+	}
+
+	/**
+	 * Gets the resource entry type of the given path.
+	 *
+	 * @param pathName the path of the resource
+	 * @return the resource entry type
+	 */
+	public EntryType getEntryType(String pathName) {
+		var entry = this.getEntry(pathName);
+
+		if (entry == null) {
+			return EntryType.EMPTY;
+		} else {
+			return entry.type();
+		}
+	}
+
+	/**
+	 * {@return the available namespaces for a given resource type}
+	 *
+	 * @param type the type of resources
+	 */
+	public Set<String> getNamespaces(ResourceType type) {
+		try {
+			var entry = this.getEntry(type.getDirectory());
+
+			if (entry == null || entry.type() != EntryType.DIRECTORY) {
+				return Collections.emptySet();
+			}
+
+			var namespaces = new HashSet<String>();
+
+			try (DirectoryStream<Path> stream = Files.newDirectoryStream(entry.path(), Files::isDirectory)) {
+				for (Path path : stream) {
+					String s = path.getFileName().toString();
+					// s may contain trailing slashes, remove them
+					s = s.replace(this.io.getSeparator(), "");
+
+					// Empty file names are disallowed anyway so no need to check for length.
+					if (IdentifierAccessor.callIsNamespaceValid(s)) {
+						namespaces.add(s);
+					} else {
+						this.warnInvalidNamespace(s);
+					}
+				}
+			}
+
+			return namespaces;
+		} catch (IOException e) {
+			LOGGER.warn("getNamespaces in mod " + this.io.getModMetadata().id() + " failed!", e);
+			return Collections.emptySet();
+		}
+	}
+
+	protected void warnInvalidNamespace(String s) {
+		LOGGER.warn("Quilt NioResourcePack: ignored invalid namespace: {} in mod ID {}", s, this.io.getModMetadata().id());
+	}
+
+	public record Entry(Path path, EntryType type) {
+	}
+}

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/ResourceAccess.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/ResourceAccess.java
@@ -53,7 +53,7 @@ public class ResourceAccess {
 	 * Gets a resource entry from the given path.
 	 *
 	 * @param pathName the path of the resource
-	 * @return the resource entry if it exists, otherwise {@code null}
+	 * @return the resource entry if it exists, or {@code null} otherwise
 	 */
 	public @Nullable Entry getEntry(String pathName) {
 		var path = this.io.getPath(pathName);

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/ResourceTreeCache.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/ResourceTreeCache.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.resource.loader.impl.cache;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.resource.ResourceType;
+
+import org.quiltmc.qsl.resource.loader.impl.ModIoOps;
+
+/**
+ * A variant of {@link ResourceAccess} that also caches I/O queries into a tree.
+ *
+ * @author LambdAurora
+ */
+@ApiStatus.Internal
+public final class ResourceTreeCache extends ResourceAccess {
+	private final CacheTree.Branch tree = CacheTree.newTree();
+	private final Map<ResourceType, Set<String>> namespaces = new EnumMap<>(ResourceType.class);
+
+	public ResourceTreeCache(ModIoOps io) {
+		super(io);
+	}
+
+	@Override
+	public @Nullable Entry getEntry(String pathName) {
+		var node = this.tree.resolveOrCompute(this.io, pathName);
+		if (node != null) {
+			return node.toEntry(this.io);
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public Set<String> getNamespaces(ResourceType type) {
+		var namespaces = this.namespaces.get(type);
+
+		if (namespaces != null) {
+			return namespaces;
+		}
+
+		namespaces = super.getNamespaces(type);
+		this.namespaces.put(type, namespaces);
+
+		return namespaces;
+	}
+}

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/ResourceTreeCache.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/cache/ResourceTreeCache.java
@@ -44,11 +44,8 @@ public final class ResourceTreeCache extends ResourceAccess {
 	@Override
 	public @Nullable Entry getEntry(String pathName) {
 		var node = this.tree.resolveOrCompute(this.io, pathName);
-		if (node != null) {
-			return node.toEntry(this.io);
-		} else {
-			return null;
-		}
+
+		return node != null ? node.toEntry(this.io) : null;
 	}
 
 	@Override

--- a/library/core/resource_loader/src/testmod/java/org/quiltmc/qsl/resource/loader/test/client/ClientResourceLoaderEventsTestMod.java
+++ b/library/core/resource_loader/src/testmod/java/org/quiltmc/qsl/resource/loader/test/client/ClientResourceLoaderEventsTestMod.java
@@ -28,15 +28,19 @@ import org.quiltmc.qsl.resource.loader.api.client.ClientResourceLoaderEvents;
 public class ClientResourceLoaderEventsTestMod implements ClientResourceLoaderEvents.StartResourcePackReload,
 		ClientResourceLoaderEvents.EndResourcePackReload {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ClientResourceLoaderEventsTestMod.class);
+	private long start;
 
 	@Override
 	public void onStartResourcePackReload(MinecraftClient client, ResourceManager resourceManager, boolean first) {
 		LOGGER.info("Preparing for resource pack reload, resource manager: {}. Is it the first time?: {}",
 				resourceManager, first);
+		this.start = System.currentTimeMillis();
 	}
 
 	@Override
 	public void onEndResourcePackReload(MinecraftClient client, ResourceManager resourceManager, boolean first, @Nullable Throwable error) {
+		LOGGER.info("Took {}ms to perform resource pack reload.", (System.currentTimeMillis() - this.start));
+
 		if (error == null) {
 			LOGGER.info("Finished {}resource pack reloading successfully on {}.",
 					(first ? "first " : ""), Thread.currentThread());


### PR DESCRIPTION
Also use the java.io.File API when possible instead of NIO exists.

## Some timings for comparison sake:

### Dev Env

#### First Reload

| Method | Time |
|:---------:|-------:| 
| No Cache, no File API | 8372 ms |
| No Cache, File API | 5664 ms |
| Cache, no File API | 8252 ms |
| Cache, File API | 8195 ms |
| Tree Cache, no File API | 6263 ms |
| Tree Cache, File API | 6178 ms |

#### World Reload

| Method | Time |
|:---------:|-------:| 
| No Cache, no File API | 1409 ms |
| No Cache, File API | 1260 ms |
| Cache, no File API | 1304 ms |
| Cache, File API | 1487 ms |
| Tree Cache, no File API | 1275 ms |
| Tree Cache, File API | 1187 ms |

### Blanketcon modpack

#### First Reload

| Method | Time |
|:---------:|-------:| 
| No Cache | 27025 ms |
| Cache | 21641 ms |
| Tree Cache | 20378 ms |

#### World Reload

| Method | Time |
|:---------:|-------:| 
| No Cache | 24566ms |
| Cache | 20721ms - 21781ms |
| Tree Cache | 19679ms - 19917ms |

In the blanketcon modpack this manages to remove almost 7 seconds of startup time!

Cache corresponds to a much simpler cache implementation with a simple ConcurrentHashMap, Tree Cache is the cache implemented in this PR.

For the dev env, only the Minecraft resource pack itself is cached by this system since the QSL dev env only has this "mod" that is eligible for caching.
Mods in dev envs that may have mutable resources via debugging will not use the cache.