### PR TITLE
Fix ModResourcePackUtil mishandling special characters.

### DIFF
--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModResourcePackUtil.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModResourcePackUtil.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import com.google.common.base.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.SharedConstants;
 import net.minecraft.resource.ResourceType;
@@ -43,22 +44,26 @@ public final class ModResourcePackUtil {
 		return "pack.mcmeta".equals(filename);
 	}
 
+	public static String getPackMeta(@Nullable String description, ResourceType type) {
+		if (description == null) {
+			description = "";
+		} else {
+			description = description.replace("\\", "\\u005C");
+			description = description.replace("\"", "\\u0022");
+		}
+
+		return String.format("""
+						{"pack":{"pack_format":%d,"description":"%s"}}
+						""",
+				type.getPackVersion(SharedConstants.getGameVersion()), description);
+	}
+
 	public static InputStream openDefault(ModMetadata info, ResourceType type, String filename) {
 		if ("pack.mcmeta".equals(filename)) {
-			String description = info.name();
-
-			if (description == null) {
-				description = "";
-			} else {
-				description = description.replaceAll("\"", "\\\"");
-			}
-
-			var pack = String.format("""
-							{"pack":{"pack_format":%d,"description":"%s"}}
-							""",
-					type.getPackVersion(SharedConstants.getGameVersion()), description);
+			var pack = getPackMeta(info.name(), type);
 			return IOUtils.toInputStream(pack, Charsets.UTF_8);
 		}
+
 		return null;
 	}
 

--- a/library/core/resource_loader/src/testmod/java/org/quiltmc/qsl/resource/loader/test/BuiltinResourcePackTestMod.java
+++ b/library/core/resource_loader/src/testmod/java/org/quiltmc/qsl/resource/loader/test/BuiltinResourcePackTestMod.java
@@ -19,6 +19,7 @@ package org.quiltmc.qsl.resource.loader.test;
 import static org.quiltmc.qsl.resource.loader.test.ResourceLoaderTestMod.id;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 
 import net.minecraft.resource.ResourceType;
@@ -56,12 +57,18 @@ public class BuiltinResourcePackTestMod implements ModInitializer {
 
 	private void testPackMetaGeneration(String name) {
 		String pack = ModResourcePackUtil.getPackMeta(name, ResourceType.CLIENT_RESOURCES);
+		JsonObject obj;
 
-		var obj = (JsonObject) JsonParser.parseString(pack);
+		try {
+			obj = (JsonObject) JsonParser.parseString(pack);
+		} catch (JsonParseException e) {
+			throw new AssertionError("Pack metadata parsing test for description \"" + name + "\".", e);
+		}
+
 		String desc = obj.getAsJsonObject("pack").get("description").getAsString();
 
 		if (!desc.equals(name == null ? "" : name)) {
-			throw new IllegalStateException("Escaped name is different from name after parsing. Got \"" + desc + "\", expected \"" + name + "\".");
+			throw new AssertionError("Escaped name is different from name after parsing. Got \"" + desc + "\", expected \"" + name + "\".");
 		}
 	}
 }


### PR DESCRIPTION
This is directly inspired from FabricMC/fabric#2407 and QSL suffers the same issue due to the implementation initially being the same.

Said PR explains really well why this is an issue and how it could happen.

Though for implementation into QSL I have chosen a different path that uses `replace` and escape first all backslashes then escape the quotes. In addition I preferred to directly use the `\u<unicode code>` format rather than creating backslash hell.

I also split the method to have the bit that generates the specific string into a separate method, easing testing which is directly done using method calling of a variety of input strings then parsing the resulting JSON.