### PR TITLE
Properly support fuel times greater than 32,767

### DIFF
--- a/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/api/ItemContentRegistries.java
+++ b/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/api/ItemContentRegistries.java
@@ -48,7 +48,7 @@ public class ItemContentRegistries {
 			.builder(Registry.ITEM,
 					new Identifier(NAMESPACE, "fuel_time"),
 					Integer.class,
-					Codec.intRange(0, Short.MAX_VALUE))
+					Codec.intRange(0, Integer.MAX_VALUE))
 			.build();
 
 	/**

--- a/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/AbstractFurnaceBlockEntityMixin.java
+++ b/library/item/item_content_registry/src/main/java/org/quiltmc/qsl/item/content/registry/mixin/AbstractFurnaceBlockEntityMixin.java
@@ -18,7 +18,9 @@ package org.quiltmc.qsl.item.content.registry.mixin;
 
 import java.util.Map;
 
+import net.minecraft.nbt.NbtCompound;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -32,6 +34,9 @@ import org.quiltmc.qsl.item.content.registry.impl.ItemContentRegistriesInitializ
 
 @Mixin(AbstractFurnaceBlockEntity.class)
 public abstract class AbstractFurnaceBlockEntityMixin {
+	@Shadow
+	private int burnTime;
+
 	@Inject(method = "createFuelTimeMap", at = @At("HEAD"), cancellable = true)
 	private static void returnCachedMap(CallbackInfoReturnable<Map<Item, Integer>> cir) {
 		if (!ItemContentRegistriesInitializer.FUEL_MAP.isEmpty()) {
@@ -45,5 +50,18 @@ public abstract class AbstractFurnaceBlockEntityMixin {
 			ItemContentRegistriesInitializer.INITIAL_FUEL_TAG_MAP.put(tag, fuelTime);
 			ci.cancel();
 		}
+	}
+
+	//Serializes burn time as an integer instead of a short
+	//Should not cause any desyncs as BE sync packets are now NBT
+
+	@Inject(method = "readNbt", at = @At("TAIL"))
+	private void readBurnTimeAsInt(NbtCompound nbt, CallbackInfo info) {
+		this.burnTime = nbt.getInt("BurnTime");
+	}
+
+	@Inject(method = "writeNbt", at = @At("TAIL"))
+	private void writeBurnTimeAsInt(NbtCompound nbt, CallbackInfo info) {
+		nbt.putInt("BurnTime", this.burnTime);
 	}
 }

--- a/library/item/item_content_registry/src/testmod/resources/data/quilt_item_content_registry/attachments/minecraft/item/fuel_time.json
+++ b/library/item/item_content_registry/src/testmod/resources/data/quilt_item_content_registry/attachments/minecraft/item/fuel_time.json
@@ -2,6 +2,7 @@
   "replace": false,
   "values": {
     "minecraft:cake": 200,
-    "minecraft:coal": 2000
+    "minecraft:coal": 2000,
+    "minecraft:coal_block": 200000
   }
 }


### PR DESCRIPTION
Closes #162 by changing `Short.MAX_VALUE` to `Integer.MAX_VALUE`. Also patches furnaces to read and write `burnTime` as a Short instead of an int - this should have full compatibility with Vanilla clients due to all BEs being synced as their NBT-serialized forms nowadays.

**WARNING: I AM NOT ABLE TO TEST THIS ON MY COMPUTER, IT THEORETICALLY SHOULD WORK BUT I HAVE NO WAY TO VERIFY, PLEASE TEST AND ENSURE THIS DOESN'T CAUSE DESYNCS WITH VANILLA CLIENTS BEFORE MERGING**