### PR TITLE
Fix DataBreaker compatibility

### DIFF
--- a/library/misc/datafixerupper/build.gradle
+++ b/library/misc/datafixerupper/build.gradle
@@ -15,10 +15,10 @@ qslModule {
 	}
 	entrypoints {
 		events {
-			values = ["org.quiltmc.qsl.datafixerupper.impl.Initializer"]
+			values = ["org.quiltmc.qsl.datafixerupper.impl.ServerFreezer"]
 		}
 		client_events {
-			values = ["org.quiltmc.qsl.datafixerupper.impl.client.ClientInitializer"]
+			values = ["org.quiltmc.qsl.datafixerupper.impl.client.ClientFreezer"]
 		}
 	}
 }

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/api/QuiltDataFixes.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/api/QuiltDataFixes.java
@@ -16,9 +16,6 @@
 
 package org.quiltmc.qsl.datafixerupper.api;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.requireNonNull;
-
 import java.util.Optional;
 import java.util.function.BiFunction;
 
@@ -34,6 +31,9 @@ import net.minecraft.util.Util;
 
 import org.quiltmc.loader.api.ModContainer;
 import org.quiltmc.qsl.datafixerupper.impl.QuiltDataFixesInternals;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Provides methods to register custom {@link DataFixer}s.
@@ -53,7 +53,7 @@ public final class QuiltDataFixes {
 	public static final BiFunction<Integer, Schema, Schema> BASE_SCHEMA = (version, parent) -> {
 		checkArgument(version == 0, "version must be 0");
 		checkArgument(parent == null, "parent must be null");
-		return QuiltDataFixesInternals.createBaseSchema();
+		return QuiltDataFixesInternals.get().createBaseSchema();
 	};
 
 	/**
@@ -75,7 +75,7 @@ public final class QuiltDataFixes {
 			throw new IllegalStateException("Can't register data fixer after registry is frozen");
 		}
 
-		QuiltDataFixesInternals.registerFixer(modId, currentVersion, dataFixer);
+		QuiltDataFixesInternals.get().registerFixer(modId, currentVersion, dataFixer);
 	}
 
 	/**
@@ -117,7 +117,7 @@ public final class QuiltDataFixes {
 	public static @NotNull Optional<DataFixer> getFixer(@NotNull String modId) {
 		requireNonNull(modId, "modId cannot be null");
 
-		QuiltDataFixesInternals.DataFixerEntry entry = QuiltDataFixesInternals.getFixerEntry(modId);
+		QuiltDataFixesInternals.DataFixerEntry entry = QuiltDataFixesInternals.get().getFixerEntry(modId);
 		if (entry == null) {
 			return Optional.empty();
 		}
@@ -147,6 +147,6 @@ public final class QuiltDataFixes {
 	 */
 	@Contract(pure = true)
 	public static boolean isFrozen() {
-		return QuiltDataFixesInternals.isFrozen();
+		return QuiltDataFixesInternals.get().isFrozen();
 	}
 }

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/NopQuiltDataFixesInternals.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/NopQuiltDataFixesInternals.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.datafixerupper.impl;
+
+import com.mojang.datafixers.DataFixer;
+import com.mojang.datafixers.schemas.Schema;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+import net.minecraft.datafixer.DataFixTypes;
+import net.minecraft.nbt.NbtCompound;
+
+// used when DataBreaker is detected
+@ApiStatus.Internal
+public final class NopQuiltDataFixesInternals extends QuiltDataFixesInternals {
+	private final Schema schema;
+
+	private boolean frozen;
+
+	public NopQuiltDataFixesInternals() {
+		this.schema = new Schema(0, null);
+
+		this.frozen = false;
+	}
+
+	@Override
+	public void registerFixer(@NotNull String modId, @Range(from = 0, to = Integer.MAX_VALUE) int currentVersion,
+			@NotNull DataFixer dataFixer) {}
+
+	@Override
+	public @Nullable DataFixerEntry getFixerEntry(@NotNull String modId) {
+		return null;
+	}
+
+	@Override
+	public @NotNull Schema createBaseSchema() {
+		return this.schema;
+	}
+
+	@Override
+	public @NotNull NbtCompound updateWithAllFixers(@NotNull DataFixTypes dataFixTypes, @NotNull NbtCompound compound) {
+		return compound.copy();
+	}
+
+	@Override
+	public @NotNull NbtCompound addModDataVersions(@NotNull NbtCompound compound) {
+		return compound;
+	}
+
+	@Override
+	public void freeze() {
+		this.frozen = true;
+	}
+
+	@Override
+	public boolean isFrozen() {
+		return this.frozen;
+	}
+}

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/NopQuiltDataFixesInternals.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/NopQuiltDataFixesInternals.java
@@ -26,7 +26,6 @@ import org.jetbrains.annotations.Range;
 import net.minecraft.datafixer.DataFixTypes;
 import net.minecraft.nbt.NbtCompound;
 
-// used when DataBreaker is detected
 @ApiStatus.Internal
 public final class NopQuiltDataFixesInternals extends QuiltDataFixesInternals {
 	private final Schema schema;

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternals.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternals.java
@@ -16,81 +16,18 @@
 
 package org.quiltmc.qsl.datafixerupper.impl;
 
-import java.util.Collections;
-import java.util.Map;
-
-import com.mojang.datafixers.DataFixUtils;
 import com.mojang.datafixers.DataFixer;
 import com.mojang.datafixers.schemas.Schema;
-import com.mojang.logging.LogUtils;
-import com.mojang.serialization.Dynamic;
-import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
 import org.jetbrains.annotations.*;
-import org.slf4j.Logger;
 
-import net.minecraft.SharedConstants;
 import net.minecraft.datafixer.DataFixTypes;
-import net.minecraft.datafixer.Schemas;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.nbt.NbtOps;
+
+import org.quiltmc.loader.api.QuiltLoader;
 
 @ApiStatus.Internal
-public final class QuiltDataFixesInternals {
-	private QuiltDataFixesInternals() { }
-
-	public static final Logger LOGGER = LogUtils.getLogger();
-
-	private static Map<String, DataFixerEntry> modDataFixers = new Object2ReferenceOpenHashMap<>();
-	private static boolean frozen = false;
-
-	public static void registerFixer(@NotNull String modId,
-									 @Range(from = 0, to = Integer.MAX_VALUE) int currentVersion,
-									 @NotNull DataFixer dataFixer) {
-		if (modDataFixers.containsKey(modId)) {
-			throw new IllegalArgumentException("Mod '" + modId + "' already has a registered data fixer");
-		}
-
-		modDataFixers.put(modId, new DataFixerEntry(dataFixer, currentVersion));
-	}
-
-	public static @Nullable DataFixerEntry getFixerEntry(@NotNull String modId) {
-		return modDataFixers.get(modId);
-	}
-
-	public static final Schema VANILLA_SCHEMA = Schemas.getFixer()
-			.getSchema(DataFixUtils.makeKey(SharedConstants.getGameVersion().getWorldVersionData().getDataVersion()));
-
-	@Contract(value = "-> new", pure = true)
-	public static @NotNull Schema createBaseSchema() {
-		return new Schema(0, VANILLA_SCHEMA);
-	}
-
-	public static @NotNull NbtCompound updateWithAllFixers(@NotNull DataFixTypes dataFixTypes,
-														   @NotNull NbtCompound compound) {
-		NbtCompound current = compound;
-
-		for (Map.Entry<String, DataFixerEntry> entry : modDataFixers.entrySet()) {
-			String currentModId = entry.getKey();
-			int modIdCurrentDynamicVersion = getModDataVersion(compound, currentModId);
-			DataFixerEntry dataFixerEntry = entry.getValue();
-
-			current = (NbtCompound) dataFixerEntry.dataFixer()
-					.update(dataFixTypes.getTypeReference(),
-							new Dynamic<>(NbtOps.INSTANCE, current),
-							modIdCurrentDynamicVersion, dataFixerEntry.currentVersion)
-					.getValue();
-		}
-
-		return current;
-	}
-
-	public static @NotNull NbtCompound addModDataVersions(@NotNull NbtCompound compound) {
-		for (Map.Entry<String, DataFixerEntry> entry : modDataFixers.entrySet()) {
-			compound.putInt(entry.getKey() + "_DataVersion", entry.getValue().currentVersion);
-		}
-
-		return compound;
-	}
+public abstract class QuiltDataFixesInternals {
+	public record DataFixerEntry(DataFixer dataFixer, int currentVersion) {}
 
 	@Contract(pure = true)
 	@Range(from = 0, to = Integer.MAX_VALUE)
@@ -98,18 +35,37 @@ public final class QuiltDataFixesInternals {
 		return compound.getInt(modId + "_DataVersion");
 	}
 
-	public static void freeze() {
-		if (!frozen) {
-			modDataFixers = Collections.unmodifiableMap(modDataFixers);
+	private static QuiltDataFixesInternals instance;
+
+	public static @NotNull QuiltDataFixesInternals get() {
+		if (instance == null) {
+			if (QuiltLoader.isModLoaded("databreaker")) {
+				instance = new NopQuiltDataFixesInternals();
+			} else {
+				instance = new QuiltDataFixesInternalsImpl();
+			}
 		}
 
-		frozen = true;
+		return instance;
 	}
+
+	public abstract void registerFixer(@NotNull String modId,
+			@Range(from = 0, to = Integer.MAX_VALUE) int currentVersion,
+			@NotNull DataFixer dataFixer);
+
+	public abstract @Nullable DataFixerEntry getFixerEntry(@NotNull String modId);
+
+	@Contract(value = "-> new", pure = true)
+	public abstract @NotNull Schema createBaseSchema();
+
+	public abstract @NotNull NbtCompound updateWithAllFixers(@NotNull DataFixTypes dataFixTypes,
+			@NotNull NbtCompound compound);
+
+	@Contract("_ -> new")
+	public abstract @NotNull NbtCompound addModDataVersions(@NotNull NbtCompound compound);
+
+	public abstract void freeze();
 
 	@Contract(pure = true)
-	public static boolean isFrozen() {
-		return frozen;
-	}
-
-	public record DataFixerEntry(DataFixer dataFixer, int currentVersion) { }
+	public abstract boolean isFrozen();
 }

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternalsImpl.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternalsImpl.java
@@ -19,7 +19,6 @@ package org.quiltmc.qsl.datafixerupper.impl;
 import java.util.Collections;
 import java.util.Map;
 
-import com.mojang.datafixers.DataFixUtils;
 import com.mojang.datafixers.DataFixer;
 import com.mojang.datafixers.schemas.Schema;
 import com.mojang.serialization.Dynamic;
@@ -29,22 +28,19 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
 
-import net.minecraft.SharedConstants;
 import net.minecraft.datafixer.DataFixTypes;
-import net.minecraft.datafixer.Schemas;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtOps;
 
 @ApiStatus.Internal
 public final class QuiltDataFixesInternalsImpl extends QuiltDataFixesInternals {
-	private final Schema vanillaSchema;
+	private final @NotNull Schema latestVanillaSchema;
 
 	private Map<String, DataFixerEntry> modDataFixers;
 	private boolean frozen;
 
-	public QuiltDataFixesInternalsImpl() {
-		this.vanillaSchema = Schemas.getFixer()
-				.getSchema(DataFixUtils.makeKey(SharedConstants.getGameVersion().getWorldVersionData().getDataVersion()));
+	public QuiltDataFixesInternalsImpl(@NotNull Schema latestVanillaSchema) {
+		this.latestVanillaSchema = latestVanillaSchema;
 
 		this.modDataFixers = new Object2ReferenceOpenHashMap<>();
 		this.frozen = false;
@@ -68,7 +64,7 @@ public final class QuiltDataFixesInternalsImpl extends QuiltDataFixesInternals {
 
 	@Override
 	public @NotNull Schema createBaseSchema() {
-		return new Schema(0, this.vanillaSchema);
+		return new Schema(0, this.latestVanillaSchema);
 	}
 
 	@Override

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternalsImpl.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternalsImpl.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.datafixerupper.impl;
+
+import java.util.Collections;
+import java.util.Map;
+
+import com.mojang.datafixers.DataFixUtils;
+import com.mojang.datafixers.DataFixer;
+import com.mojang.datafixers.schemas.Schema;
+import com.mojang.serialization.Dynamic;
+import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Range;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.datafixer.DataFixTypes;
+import net.minecraft.datafixer.Schemas;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtOps;
+
+@ApiStatus.Internal
+public final class QuiltDataFixesInternalsImpl extends QuiltDataFixesInternals {
+	private final Schema vanillaSchema;
+
+	private Map<String, DataFixerEntry> modDataFixers;
+	private boolean frozen;
+
+	public QuiltDataFixesInternalsImpl() {
+		this.vanillaSchema = Schemas.getFixer()
+				.getSchema(DataFixUtils.makeKey(SharedConstants.getGameVersion().getWorldVersionData().getDataVersion()));
+
+		this.modDataFixers = new Object2ReferenceOpenHashMap<>();
+		this.frozen = false;
+	}
+
+	@Override
+	public void registerFixer(@NotNull String modId,
+			@Range(from = 0, to = Integer.MAX_VALUE) int currentVersion,
+			@NotNull DataFixer dataFixer) {
+		if (this.modDataFixers.containsKey(modId)) {
+			throw new IllegalArgumentException("Mod '" + modId + "' already has a registered data fixer");
+		}
+
+		this.modDataFixers.put(modId, new DataFixerEntry(dataFixer, currentVersion));
+	}
+
+	@Override
+	public @Nullable DataFixerEntry getFixerEntry(@NotNull String modId) {
+		return modDataFixers.get(modId);
+	}
+
+	@Override
+	public @NotNull Schema createBaseSchema() {
+		return new Schema(0, this.vanillaSchema);
+	}
+
+	@Override
+	public @NotNull NbtCompound updateWithAllFixers(@NotNull DataFixTypes dataFixTypes,
+			@NotNull NbtCompound compound) {
+		var current = new Dynamic<>(NbtOps.INSTANCE, compound);
+
+		for (Map.Entry<String, DataFixerEntry> entry : this.modDataFixers.entrySet()) {
+			int modDataVersion = QuiltDataFixesInternals.getModDataVersion(compound, entry.getKey());
+			DataFixerEntry dataFixerEntry = entry.getValue();
+
+			current = dataFixerEntry.dataFixer()
+					.update(dataFixTypes.getTypeReference(),
+							current,
+							modDataVersion, dataFixerEntry.currentVersion());
+		}
+
+		return (NbtCompound) current.getValue();
+	}
+
+	@Override
+	public @NotNull NbtCompound addModDataVersions(@NotNull NbtCompound compound) {
+		for (Map.Entry<String, DataFixerEntry> entry : this.modDataFixers.entrySet()) {
+			compound.putInt(entry.getKey() + "_DataVersion", entry.getValue().currentVersion());
+		}
+
+		return compound;
+	}
+
+	@Override
+	public void freeze() {
+		if (!this.frozen) {
+			modDataFixers = Collections.unmodifiableMap(this.modDataFixers);
+		}
+
+		this.frozen = true;
+	}
+
+	@Override
+	public boolean isFrozen() {
+		return this.frozen;
+	}
+
+}

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/ServerFreezer.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/ServerFreezer.java
@@ -23,9 +23,9 @@ import net.minecraft.server.MinecraftServer;
 import org.quiltmc.qsl.lifecycle.api.event.ServerLifecycleEvents;
 
 @ApiStatus.Internal
-public final class Initializer implements ServerLifecycleEvents.Starting {
+public final class ServerFreezer implements ServerLifecycleEvents.Starting {
 	@Override
 	public void startingServer(MinecraftServer server) {
-		QuiltDataFixesInternals.freeze();
+		QuiltDataFixesInternals.get().freeze();
 	}
 }

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/client/ClientFreezer.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/client/ClientFreezer.java
@@ -27,9 +27,9 @@ import org.quiltmc.qsl.lifecycle.api.client.event.ClientLifecycleEvents;
 
 @Environment(EnvType.CLIENT)
 @ApiStatus.Internal
-public final class ClientInitializer implements ClientLifecycleEvents.Ready {
+public final class ClientFreezer implements ClientLifecycleEvents.Ready {
 	@Override
 	public void readyClient(MinecraftClient client) {
-		QuiltDataFixesInternals.freeze();
+		QuiltDataFixesInternals.get().freeze();
 	}
 }

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/mixin/ChunkSerializerMixin.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/mixin/ChunkSerializerMixin.java
@@ -32,6 +32,6 @@ public abstract class ChunkSerializerMixin {
 			at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/NbtCompound;putInt(Ljava/lang/String;I)V", ordinal = 0)
 	)
 	private static NbtCompound addModDataVersions(NbtCompound compound) {
-		return QuiltDataFixesInternals.addModDataVersions(compound);
+		return QuiltDataFixesInternals.get().addModDataVersions(compound);
 	}
 }

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/mixin/NbtHelperMixin.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/mixin/NbtHelperMixin.java
@@ -37,6 +37,6 @@ public abstract class NbtHelperMixin {
 	)
 	private static void updateDataWithFixers(DataFixer fixer, DataFixTypes fixTypes, NbtCompound compound,
 											 int oldVersion, int targetVersion, CallbackInfoReturnable<NbtCompound> cir) {
-		cir.setReturnValue(QuiltDataFixesInternals.updateWithAllFixers(fixTypes, cir.getReturnValue()));
+		cir.setReturnValue(QuiltDataFixesInternals.get().updateWithAllFixers(fixTypes, cir.getReturnValue()));
 	}
 }

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/mixin/PlayerEntityMixin.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/mixin/PlayerEntityMixin.java
@@ -30,6 +30,6 @@ import org.quiltmc.qsl.datafixerupper.impl.QuiltDataFixesInternals;
 public abstract class PlayerEntityMixin {
 	@Inject(method = "writeCustomDataToNbt", at = @At("RETURN"))
 	public void addModDataVersions(NbtCompound compound, CallbackInfo ci) {
-		QuiltDataFixesInternals.addModDataVersions(compound);
+		QuiltDataFixesInternals.get().addModDataVersions(compound);
 	}
 }

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/mixin/StructureMixin.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/mixin/StructureMixin.java
@@ -31,7 +31,7 @@ public abstract class StructureMixin {
 	@Inject(method = "writeNbt", at = @At("TAIL"), cancellable = true)
 	private void addModDataVersions(NbtCompound compound, CallbackInfoReturnable<NbtCompound> cir) {
 		NbtCompound out = cir.getReturnValue();
-		QuiltDataFixesInternals.getUnsynchronized().addModDataVersions(out);
+		QuiltDataFixesInternals.get().addModDataVersions(out);
 		cir.setReturnValue(out);
 	}
 }

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/mixin/StructureMixin.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/mixin/StructureMixin.java
@@ -31,7 +31,7 @@ public abstract class StructureMixin {
 	@Inject(method = "writeNbt", at = @At("TAIL"), cancellable = true)
 	private void addModDataVersions(NbtCompound compound, CallbackInfoReturnable<NbtCompound> cir) {
 		NbtCompound out = cir.getReturnValue();
-		QuiltDataFixesInternals.addModDataVersions(out);
+		QuiltDataFixesInternals.getUnsynchronized().addModDataVersions(out);
 		cir.setReturnValue(out);
 	}
 }

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/mixin/client/HotbarStorageMixin.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/mixin/client/HotbarStorageMixin.java
@@ -35,6 +35,6 @@ public abstract class HotbarStorageMixin {
 			locals = LocalCapture.CAPTURE_FAILHARD
 	)
 	private void addModDataVersions(CallbackInfo ci, NbtCompound compound) {
-		QuiltDataFixesInternals.addModDataVersions(compound);
+		QuiltDataFixesInternals.get().addModDataVersions(compound);
 	}
 }


### PR DESCRIPTION
...by slightly over-complicating the DataFixerUpper module's internals.

There are now 2 implementations of `DataFixerUpperInternals`:
1. `DataFixerUpperInternalsImpl`, which contains the code the module used until now (including the code that causes a crash with DataBreaker),
2. `NopDataFixerUpperInternals`, which as the name implies is a no-op implementation (that still complies with the contracts) that is used if DataBreaker is installed.