### PR TITLE
REA: Value mirroring system

### DIFF
--- a/library/data/registry_entry_attachments/src/main/java/org/quiltmc/qsl/registry/attachment/api/RegistryEntryAttachment.java
+++ b/library/data/registry_entry_attachments/src/main/java/org/quiltmc/qsl/registry/attachment/api/RegistryEntryAttachment.java
@@ -283,6 +283,26 @@ public interface RegistryEntryAttachment<R, V> extends Iterable<RegistryEntryAtt
 	boolean remove(TagKey<R> tag);
 
 	/**
+	 * Mirrors the value associated with the source entry to the target entry.
+	 * <p>
+	 * This mirror mapping persists across reloads and {@link #put(Object, Object)}s!
+	 *
+	 * @param target the target entry to mirror the value onto
+	 * @param source the source entry to mirror the value from
+	 */
+	void mirror(R target, R source);
+
+	/**
+	 * Mirrors the value associated with the source tag to the target tag.
+	 * <p>
+	 * This mirror mapping persists across reloads and {@link #put(TagKey, Object)}s!
+	 *
+	 * @param target the target tag to mirror the value onto
+	 * @param source the source tag to mirror the value from
+	 */
+	void mirror(TagKey<R> target, TagKey<R> source);
+
+	/**
 	 * {@return this attachment's "value associated with entry" event}
 	 */
 	Event<ValueAdded<R, V>> valueAddedEvent();

--- a/library/data/registry_entry_attachments/src/main/java/org/quiltmc/qsl/registry/attachment/impl/DataRegistryEntryAttachmentHolder.java
+++ b/library/data/registry_entry_attachments/src/main/java/org/quiltmc/qsl/registry/attachment/impl/DataRegistryEntryAttachmentHolder.java
@@ -28,6 +28,7 @@ public final class DataRegistryEntryAttachmentHolder<R> extends RegistryEntryAtt
 	 */
 	public void prepareReloadSource(ResourceType source) {
 		this.valueTagTable.rowKeySet().removeIf(attach -> attach.side().shouldLoad(source));
+		this.mirrorTable.rowKeySet().removeIf(attach -> attach.side().shouldLoad(source));
 		this.valueTable.rowKeySet().removeIf(attach -> attach.side().shouldLoad(source));
 	}
 }

--- a/library/data/registry_entry_attachments/src/main/java/org/quiltmc/qsl/registry/attachment/impl/DataRegistryEntryAttachmentHolder.java
+++ b/library/data/registry_entry_attachments/src/main/java/org/quiltmc/qsl/registry/attachment/impl/DataRegistryEntryAttachmentHolder.java
@@ -27,6 +27,7 @@ public final class DataRegistryEntryAttachmentHolder<R> extends RegistryEntryAtt
 	 * @param source source that we're preparing to reload
 	 */
 	public void prepareReloadSource(ResourceType source) {
+		this.mirrorTagTable.rowKeySet().removeIf(attach -> attach.side().shouldLoad(source));
 		this.valueTagTable.rowKeySet().removeIf(attach -> attach.side().shouldLoad(source));
 		this.mirrorTable.rowKeySet().removeIf(attach -> attach.side().shouldLoad(source));
 		this.valueTable.rowKeySet().removeIf(attach -> attach.side().shouldLoad(source));

--- a/library/data/registry_entry_attachments/src/main/java/org/quiltmc/qsl/registry/attachment/impl/RegistryEntryAttachmentImpl.java
+++ b/library/data/registry_entry_attachments/src/main/java/org/quiltmc/qsl/registry/attachment/impl/RegistryEntryAttachmentImpl.java
@@ -117,9 +117,7 @@ public abstract class RegistryEntryAttachmentImpl<R, V> implements RegistryEntry
 			ClientSideGuard.assertAccessAllowed();
 		}
 
-		while (this.mirrors.containsKey(entry)) {
-			entry = this.mirrors.get(entry);
-		}
+		entry = this.unreflect(entry);
 
 		V value = RegistryEntryAttachmentHolder.getData(this.registry).getValue(this, entry);
 		if (value != null) {
@@ -140,9 +138,7 @@ public abstract class RegistryEntryAttachmentImpl<R, V> implements RegistryEntry
 			ClientSideGuard.assertAccessAllowed();
 		}
 
-		while (this.tagMirrors.containsKey(key)) {
-			key = this.tagMirrors.get(key);
-		}
+		key = this.unreflect(key);
 
 		V value = (V) RegistryEntryAttachmentHolder.getData(this.registry).valueTagTable.get(this, key);
 		if (value != null) {

--- a/library/data/registry_entry_attachments/src/main/java/org/quiltmc/qsl/registry/attachment/impl/RegistryEntryAttachmentImpl.java
+++ b/library/data/registry_entry_attachments/src/main/java/org/quiltmc/qsl/registry/attachment/impl/RegistryEntryAttachmentImpl.java
@@ -277,6 +277,7 @@ public abstract class RegistryEntryAttachmentImpl<R, V> implements RegistryEntry
 	}
 
 	public void rebuildMirrorMaps() {
+		// TODO check for mirror loops (one -> two, two -> one)
 		this.mirrors.clear();
 		this.mirrors.putAll(RegistryEntryAttachmentHolder.getBuiltin(this.registry).mirrorTable.row(this));
 		this.mirrors.putAll(RegistryEntryAttachmentHolder.getData(this.registry).mirrorTable.row(this));

--- a/library/data/registry_entry_attachments/src/main/java/org/quiltmc/qsl/registry/attachment/impl/reloader/AttachmentDictionary.java
+++ b/library/data/registry_entry_attachments/src/main/java/org/quiltmc/qsl/registry/attachment/impl/reloader/AttachmentDictionary.java
@@ -282,6 +282,11 @@ final class AttachmentDictionary<R, V> {
 					continue;
 				}
 
+				if (source.equals(target)) {
+					LOGGER.error("Invalid mirror '{}' in {}: can't mirror self, ignoring",
+							target, resourceId);
+				}
+
 				map.put(target, source);
 			} else {
 				LOGGER.error("Invalid mirror '{}' in {}: expected string, got {}; ignoring",


### PR DESCRIPTION
This PR introduces _mirrors_, to allow an entry to copy a value from another entry.

In addition to the `mirror(R, R)` and `mirror(TagKey<R>, TagKey<R>)` methods in `RegistryEntryAttributes`, this also adds the following elements to attachment dictionary JSONs:
```json5
{
  "replace_mirrors": false, // if "true", all data-driven mirrors are cleared
  "mirrors": {
    "target_id": "source_id" // source_id's value is mirrored to target_id
  },
  "replace_tag_mirrors": false, // if "true", all data-driven tag mirrors are cleared
  "tag_mirrors": {
    "target_tag": "source_tag" // source_tag's value is mirrored to target_tag
  }
}
```

### TODO
- [ ] Detect and drop mirror cycles (a -> b, b -> a)
- [ ] Combine the two `mirrors` JSON objects?
- [ ] Add Javadoc about mirror removal to `put` and `remove`