### PR TITLE
DataBreaker compatibility 2: NPE boogaloo

### DIFF
--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 	implementation "org.quiltmc:loom:0.12.+"
 	implementation "net.kyori:indra-git:2.0.2"
 	implementation "org.quiltmc:quilt-json5:1.0.0"
-	implementation "org.quiltmc:quilt-gradle-licenser:1.1.+"
+	implementation "org.quiltmc:quilt-gradle-licenser:1.+"
 	implementation "com.diffplug.spotless:spotless-plugin-gradle:5.12.4"
 }
 

--- a/build-logic/src/main/java/qsl/internal/Versions.java
+++ b/build-logic/src/main/java/qsl/internal/Versions.java
@@ -3,12 +3,14 @@ package qsl.internal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Version constants used across the convention build scripts.
  * <p>
  * To use inside of convention build scripts, simply import this class and refer to the public static final fields.
  */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public final class Versions {
 	/*
 	 * These must be in a Java class file due to issues with keeping this data in the groovy source set, since the
@@ -47,6 +49,18 @@ public final class Versions {
 	 * The target Java version.
 	 */
 	public static final int JAVA_VERSION = 17; // Minecraft is Java 17
+
+	//region 3rd-parties libraries/mods to test
+	/**
+	 * The version of Databreaker to use in the DFU testmod V1.
+	 */
+	public static Optional<String> DATABREAKER_VERSION = Optional.empty();
+
+	/**
+	 * The version of LazyDFU to use in the DFU testmods.
+	 */
+	public static Optional<String> LAZYDFU_VERSION = Optional.of("0.1.3");
+	//endregion
 
 	private Versions() {
 	}

--- a/library/misc/datafixerupper/build.gradle
+++ b/library/misc/datafixerupper/build.gradle
@@ -38,7 +38,29 @@ sourceSets {
 	}
 }
 
+repositories {
+	maven {
+		name = "Gegy's Maven"
+		url = "https://maven.gegy.dev/"
+	}
+
+	maven {
+		name = "Modrinth Maven"
+		url = "https://api.modrinth.com/maven"
+		content {
+			includeGroupByRegex "maven\\.modrinth"
+		}
+	}
+}
+
 dependencies {
+	// TODO dehardcode versions
+	modLocalRuntime "maven.modrinth:lazydfu:0.1.3"
+
+	/*testmodLocalRuntime("supercoder79:databreaker:0.2.10") {
+		exclude module: "fabric-loader"
+	}*/
+
 	testmodV1Implementation sourceSets.main.output
 	testmodV2Implementation sourceSets.main.output
 	testmodV3Implementation sourceSets.main.output

--- a/library/misc/datafixerupper/build.gradle
+++ b/library/misc/datafixerupper/build.gradle
@@ -1,3 +1,5 @@
+import qsl.internal.Versions
+
 plugins {
 	id("qsl.module")
 }
@@ -36,12 +38,19 @@ sourceSets {
 		compileClasspath += main.compileClasspath
 		runtimeClasspath += main.runtimeClasspath
 	}
+	testmodNoop {
+		compileClasspath += main.compileClasspath
+		runtimeClasspath += main.runtimeClasspath
+	}
 }
 
 repositories {
 	maven {
 		name = "Gegy's Maven"
 		url = "https://maven.gegy.dev/"
+		content {
+			includeGroup "supercoder79"
+		}
 	}
 
 	maven {
@@ -50,36 +59,6 @@ repositories {
 		content {
 			includeGroupByRegex "maven\\.modrinth"
 		}
-	}
-}
-
-dependencies {
-	// TODO dehardcode versions
-	modLocalRuntime "maven.modrinth:lazydfu:0.1.3"
-
-	/*testmodLocalRuntime("supercoder79:databreaker:0.2.10") {
-		exclude module: "fabric-loader"
-	}*/
-
-	testmodV1Implementation sourceSets.main.output
-	testmodV2Implementation sourceSets.main.output
-	testmodV3Implementation sourceSets.main.output
-}
-
-task prepareDfuTestmod {
-	doLast {
-		delete "run"
-		mkdir "run"
-		logger.quiet("NOTE: By running this testmod, you automatically agree to the EULA.")
-		file("run/eula.txt").text = "eula=true"
-
-		// We want fast world generation for those tests.
-		// Change the port to another one so it doesn't conflict with the main test server in case of running in parallel.
-		file("run/server.properties").text = '''\
-level-type=flat
-allow-nether=false
-server-port=25585
-'''
 	}
 }
 
@@ -108,6 +87,62 @@ loom {
 			property("quilt.auto_test")
 			programArg("--nogui")
 		}
+
+		Versions.DATABREAKER_VERSION.ifPresent {
+			autoTestServerDfuTestmodNoop {
+				server()
+				configName = "Auto test server - DFU testmod no-op"
+				source(project.sourceSets.testmodNoop)
+				property("quilt.auto_test")
+				programArg("--nogui")
+				runDir("run/noop")
+			}
+		}
+	}
+
+	/*
+	TODO: update to loom 0.13 and use this to add databreaker and lazydfu properly
+	createRemapConfigurations(sourceSets.testmodV1)
+	createRemapConfigurations(sourceSets.testmodV2)
+	createRemapConfigurations(sourceSets.testmodV3)
+	createRemapConfigurations(sourceSets.testmodNoop)
+	 */
+}
+
+dependencies {
+	testmodV1Implementation sourceSets.main.output
+	testmodV2Implementation sourceSets.main.output
+	testmodV3Implementation sourceSets.main.output
+
+	/*
+	TODO: update to loom 0.13 and use this to add databreaker and lazydfu properly
+	Versions.DATABREAKER_VERSION.ifPresent {
+		modTestmodNoopRuntimeOnly("supercoder79:databreaker:${it}") {
+			exclude module: "fabric-loader"
+		}
+	}
+	Versions.LAZYDFU_VERSION.ifPresent {
+		modTestmodV1RuntimeOnly("maven.modrinth:lazydfu:${it}") {
+			exclude module: "fabric-loader"
+		}
+	}
+	*/
+}
+
+task prepareDfuTestmod {
+	doLast {
+		delete "run"
+		mkdir "run"
+		logger.quiet("NOTE: By running this testmod, you automatically agree to the EULA.")
+		file("run/eula.txt").text = "eula=true"
+
+		// We want fast world generation for those tests.
+		// Change the port to another one so it doesn't conflict with the main test server in case of running in parallel.
+		file("run/server.properties").text = '''\
+level-type=flat
+allow-nether=false
+server-port=25585
+'''
 	}
 }
 
@@ -119,4 +154,8 @@ afterEvaluate {
 	runAutoTestServerDfuTestmodV3.dependsOn runAutoTestServerDfuTestmodV2
 
 	rootProject.tasks.runAutoAllTestServer.dependsOn runAutoTestServerDfuTestmodV3
+
+	Versions.DATABREAKER_VERSION.ifPresent {
+		rootProject.tasks.runAutoAllTestServer.dependsOn runAutoTestServerDfuTestmodNoop
+	}
 }

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/api/EmptySchema.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/api/EmptySchema.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.datafixerupper.api;
+
+import java.util.function.Supplier;
+
+import com.mojang.datafixers.DSL;
+import com.mojang.datafixers.schemas.Schema;
+import com.mojang.datafixers.types.templates.TypeTemplate;
+import org.jetbrains.annotations.Range;
+
+/**
+ * Represents an empty {@link Schema}, having no parent and containing no type definitions.
+ */
+public final class EmptySchema extends FirstSchema {
+	/**
+	 * Constructs an empty schema.
+	 * @param versionKey the data version key
+	 */
+	public EmptySchema(@Range(from = 0, to = Integer.MAX_VALUE) int versionKey) {
+		super(versionKey);
+	}
+
+	// ensure the schema stays empty
+	@Override
+	public void registerType(boolean recursive, DSL.TypeReference type, Supplier<TypeTemplate> template) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/api/FirstSchema.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/api/FirstSchema.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.datafixerupper.api;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import com.mojang.datafixers.schemas.Schema;
+import com.mojang.datafixers.types.templates.TypeTemplate;
+import org.jetbrains.annotations.Range;
+
+/**
+ * Represents a {@link Schema} that has no parent.
+ */
+public class FirstSchema extends Schema {
+	/**
+	 * Creates a schema.
+	 * @param versionKey the data version key
+	 */
+	public FirstSchema(@Range(from = 0, to = Integer.MAX_VALUE) int versionKey) {
+		super(versionKey, null);
+	}
+
+	// all of these methods refer to this.parent without checking if its null
+	@Override
+	public void registerTypes(Schema schema, Map<String, Supplier<TypeTemplate>> entityTypes,
+			Map<String, Supplier<TypeTemplate>> blockEntityTypes) {}
+
+	@Override
+	public Map<String, Supplier<TypeTemplate>> registerEntities(Schema schema) {
+		return Map.of();
+	}
+
+	@Override
+	public Map<String, Supplier<TypeTemplate>> registerBlockEntities(Schema schema) {
+		return Map.of();
+	}
+}

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/NoOpQuiltDataFixesInternals.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/NoOpQuiltDataFixesInternals.java
@@ -29,12 +29,12 @@ import net.minecraft.nbt.NbtCompound;
 import org.quiltmc.qsl.datafixerupper.api.EmptySchema;
 
 @ApiStatus.Internal
-public final class NopQuiltDataFixesInternals extends QuiltDataFixesInternals {
+public final class NoOpQuiltDataFixesInternals extends QuiltDataFixesInternals {
 	private final Schema schema;
 
 	private boolean frozen;
 
-	public NopQuiltDataFixesInternals() {
+	public NoOpQuiltDataFixesInternals() {
 		this.schema = new EmptySchema(0);
 
 		this.frozen = false;

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/NopQuiltDataFixesInternals.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/NopQuiltDataFixesInternals.java
@@ -26,6 +26,8 @@ import org.jetbrains.annotations.Range;
 import net.minecraft.datafixer.DataFixTypes;
 import net.minecraft.nbt.NbtCompound;
 
+import org.quiltmc.qsl.datafixerupper.api.EmptySchema;
+
 @ApiStatus.Internal
 public final class NopQuiltDataFixesInternals extends QuiltDataFixesInternals {
 	private final Schema schema;
@@ -33,7 +35,7 @@ public final class NopQuiltDataFixesInternals extends QuiltDataFixesInternals {
 	private boolean frozen;
 
 	public NopQuiltDataFixesInternals() {
-		this.schema = new Schema(0, null);
+		this.schema = new EmptySchema(0);
 
 		this.frozen = false;
 	}

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternals.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternals.java
@@ -64,8 +64,7 @@ public abstract class QuiltDataFixesInternals {
 		return instance;
 	}
 
-	public abstract void registerFixer(@NotNull String modId,
-			@Range(from = 0, to = Integer.MAX_VALUE) int currentVersion,
+	public abstract void registerFixer(@NotNull String modId, @Range(from = 0, to = Integer.MAX_VALUE) int currentVersion,
 			@NotNull DataFixer dataFixer);
 
 	public abstract @Nullable DataFixerEntry getFixerEntry(@NotNull String modId);
@@ -73,8 +72,7 @@ public abstract class QuiltDataFixesInternals {
 	@Contract(value = "-> new", pure = true)
 	public abstract @NotNull Schema createBaseSchema();
 
-	public abstract @NotNull NbtCompound updateWithAllFixers(@NotNull DataFixTypes dataFixTypes,
-			@NotNull NbtCompound compound);
+	public abstract @NotNull NbtCompound updateWithAllFixers(@NotNull DataFixTypes dataFixTypes, @NotNull NbtCompound compound);
 
 	@Contract("_ -> new")
 	public abstract @NotNull NbtCompound addModDataVersions(@NotNull NbtCompound compound);

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternals.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternals.java
@@ -77,7 +77,6 @@ public abstract class QuiltDataFixesInternals {
 	public abstract @NotNull NbtCompound updateWithAllFixers(@NotNull DataFixTypes dataFixTypes,
 			@NotNull NbtCompound compound);
 
-	@Contract("_ -> new")
 	public abstract @NotNull NbtCompound addModDataVersions(@NotNull NbtCompound compound);
 
 	public abstract void freeze();

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternals.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternals.java
@@ -19,11 +19,9 @@ package org.quiltmc.qsl.datafixerupper.impl;
 import com.mojang.datafixers.DataFixUtils;
 import com.mojang.datafixers.DataFixer;
 import com.mojang.datafixers.schemas.Schema;
-import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.Range;
+import com.mojang.logging.LogUtils;
+import org.jetbrains.annotations.*;
+import org.slf4j.Logger;
 
 import net.minecraft.SharedConstants;
 import net.minecraft.datafixer.DataFixTypes;
@@ -32,6 +30,8 @@ import net.minecraft.nbt.NbtCompound;
 
 @ApiStatus.Internal
 public abstract class QuiltDataFixesInternals {
+	private static final Logger LOGGER = LogUtils.getLogger();
+
 	public record DataFixerEntry(DataFixer dataFixer, int currentVersion) {}
 
 	@Contract(pure = true)
@@ -53,9 +53,10 @@ public abstract class QuiltDataFixesInternals {
 			}
 
 			if (latestVanillaSchema == null) {
-				// either this Minecraft version is horribly broken, or someone is suppressing DFU initialization
-				// use a no-op impl
-				instance = new NopQuiltDataFixesInternals();
+				LOGGER.warn("[Quilt DFU API] Failed to initialize! Either someone stopped DFU from initializing,");
+				LOGGER.warn("[Quilt DFU API]  or this Minecraft build is hosed.");
+				LOGGER.warn("[Quilt DFU API] Using no-op implementation.");
+				instance = new NoOpQuiltDataFixesInternals();
 			} else {
 				instance = new QuiltDataFixesInternalsImpl(latestVanillaSchema);
 			}

--- a/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternalsImpl.java
+++ b/library/misc/datafixerupper/src/main/java/org/quiltmc/qsl/datafixerupper/impl/QuiltDataFixesInternalsImpl.java
@@ -47,8 +47,7 @@ public final class QuiltDataFixesInternalsImpl extends QuiltDataFixesInternals {
 	}
 
 	@Override
-	public void registerFixer(@NotNull String modId,
-			@Range(from = 0, to = Integer.MAX_VALUE) int currentVersion,
+	public void registerFixer(@NotNull String modId, @Range(from = 0, to = Integer.MAX_VALUE) int currentVersion,
 			@NotNull DataFixer dataFixer) {
 		if (this.modDataFixers.containsKey(modId)) {
 			throw new IllegalArgumentException("Mod '" + modId + "' already has a registered data fixer");
@@ -68,8 +67,7 @@ public final class QuiltDataFixesInternalsImpl extends QuiltDataFixesInternals {
 	}
 
 	@Override
-	public @NotNull NbtCompound updateWithAllFixers(@NotNull DataFixTypes dataFixTypes,
-			@NotNull NbtCompound compound) {
+	public @NotNull NbtCompound updateWithAllFixers(@NotNull DataFixTypes dataFixTypes, @NotNull NbtCompound compound) {
 		var current = new Dynamic<>(NbtOps.INSTANCE, compound);
 
 		for (Map.Entry<String, DataFixerEntry> entry : this.modDataFixers.entrySet()) {

--- a/library/misc/datafixerupper/src/testmodNoop/resources/quilt.mod.json
+++ b/library/misc/datafixerupper/src/testmodNoop/resources/quilt.mod.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "quilt_loader": {
+    "group": "org.quiltmc.qsl.datafixerupper",
+    "id": "quilt_datafixerupper_noop_testmod",
+    "version": "1.0.0",
+    "metadata": {
+      "name": "Quilt DataFixerUpper API No-op Test Mod",
+      "description": "Testmod for Quilt APIs relating to DataFixers.",
+      "license": "Apache-2.0",
+      "contact": {
+        "homepage": "https://quiltmc.org",
+        "issues": "https://github.com/QuiltMC/quilt-standard-libraries/issues",
+        "sources": "https://github.com/QuiltMC/quilt-standard-libraries"
+      },
+      "contributors": {
+        "QuiltMC: QSL Team": "Author"
+      }
+    },
+    "intermediate_mappings": "net.fabricmc:intermediary",
+    "load_type": "always",
+    "depends": [
+      "quilt_loader",
+      "quilt_datafixerupper",
+      "databreaker"
+    ]
+  }
+}


### PR DESCRIPTION
- [x] Add `FirstSchema`, to allow for parentless schemas.
- [x] Add `EmptySchema`. It's a schema void of types. Used when DataBreaker is installed, since we don't have a vanilla schema to use instead.
- [ ] Add tests for DataBreaker. _(requires Loom 0.13)_
- [ ] Add tests for LazyDFU. _(requires Loom 0.13)_