### PR TITLE
NetworkChannels.

### DIFF
--- a/library/core/networking/build.gradle
+++ b/library/core/networking/build.gradle
@@ -12,6 +12,8 @@ qslModule {
 		core {
 			api("qsl_base")
 			api("lifecycle_events")
+			testmodOnly("registry")
+			testmodOnly("resource_loader")
 		}
 		management {
 			testmodOnly("command")

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/C2SNetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/C2SNetworkChannel.java
@@ -1,28 +1,58 @@
 package org.quiltmc.qsl.networking.api.channel;
 
-import net.minecraft.network.NetworkSide;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 
 import org.quiltmc.qsl.networking.api.PacketSender;
+import org.quiltmc.qsl.networking.api.ServerPlayNetworking;
 import org.quiltmc.qsl.networking.api.client.ClientPlayNetworking;
 
+/**
+ * A network channel that can send messages from client to server.
+ *
+ * @param <T> the type of messages this channel can send
+ */
 public interface C2SNetworkChannel<T> extends NetworkChannel<T> {
-	// TODO: Add environment annotations
+	/**
+	 * Send a message from the current client to the server.
+	 *
+	 * @param t the message to send
+	 */
+	@Environment(EnvType.CLIENT)
 	default void send(T t) {
-		ClientPlayNetworking.send(this.getId(), this.getCodec().createBuffer(t));
+		ClientPlayNetworking.send(this.id(), this.codec().createBuffer(t));
 	}
 
-	@Override
-	default NetworkSide getSide() {
-		return NetworkSide.SERVERBOUND;
-	}
+	/**
+	 * Creates a {@link ServerPlayNetworking.ChannelReceiver} that uses this {@link NetworkChannel}'s
+	 * {@linkplain org.quiltmc.qsl.networking.api.codec.NetworkCodec codec} to decode messages and can handle them.
+	 *
+	 * @return a {@link ServerPlayNetworking.ChannelReceiver} that can receive messages from this
+	 * {@link NetworkChannel}
+	 */
+	ServerPlayNetworking.ChannelReceiver createServerReceiver();
 
+	/**
+	 * Interface used to handle messages on the server.
+	 */
+	@FunctionalInterface
 	interface Handler {
+		/**
+		 * Handles a message on the server.
+		 *
+		 * @param server         the server
+		 * @param sender         the player who sent the message
+		 * @param handler        the {@link ServerPlayNetworkHandler} that received the message
+		 * @param responseSender the {@link PacketSender} to use to send responses
+		 * @apiNote This method is called on the main thread.
+		 */
 		void serverHandle(
 				MinecraftServer server,
-				ServerPlayerEntity player,
+				ServerPlayerEntity sender,
 				ServerPlayNetworkHandler handler,
 				PacketSender responseSender
 		);

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/C2SNetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/C2SNetworkChannel.java
@@ -1,0 +1,30 @@
+package org.quiltmc.qsl.networking.api.channel;
+
+import net.minecraft.network.NetworkSide;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import org.quiltmc.qsl.networking.api.PacketSender;
+import org.quiltmc.qsl.networking.api.client.ClientPlayNetworking;
+
+public interface C2SNetworkChannel<T> extends NetworkChannel<T> {
+	// TODO: Add environment annotations
+	default void send(T t) {
+		ClientPlayNetworking.send(this.getId(), this.getCodec().createBuffer(t));
+	}
+
+	@Override
+	default NetworkSide getSide() {
+		return NetworkSide.SERVERBOUND;
+	}
+
+	interface Handler {
+		void serverHandle(
+				MinecraftServer server,
+				ServerPlayerEntity player,
+				ServerPlayNetworkHandler handler,
+				PacketSender responseSender
+		);
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/C2SNetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/C2SNetworkChannel.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.api.channel;
 
 import net.fabricmc.api.EnvType;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/NetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/NetworkChannel.java
@@ -1,0 +1,51 @@
+package org.quiltmc.qsl.networking.api.channel;
+
+import java.util.function.Function;
+
+import net.minecraft.network.NetworkSide;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+import org.quiltmc.qsl.networking.api.PacketSender;
+import org.quiltmc.qsl.networking.api.ServerPlayNetworking;
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+import org.quiltmc.qsl.networking.impl.channel.SimpleC2SNetworkChannel;
+
+public interface NetworkChannel<T> {
+	C2SNetworkChannel<Ctx> CTX = NetworkChannel.simpleC2S(
+			new Identifier("test", "ctx"),
+			NetworkCodec.INT.mapInt(Ctx::i, Ctx::new)
+	);
+
+	static <T> SimpleC2SNetworkChannel<T> simpleC2S(Identifier id, NetworkCodec<T> codec, Function<T, C2SNetworkChannel.Handler> transform) {
+		SimpleC2SNetworkChannel<T> channel = new SimpleC2SNetworkChannel<>(id, codec, transform);
+		ServerPlayNetworking.registerGlobalReceiver(channel.id(), (server, player, handler, buf, responseSender) -> {
+			T data = channel.codec().decode(buf);
+			channel.transform().apply(data).serverHandle(server, player, handler, responseSender);
+		});
+
+		return channel;
+	}
+
+	static <T extends C2SNetworkChannel.Handler> SimpleC2SNetworkChannel<T> simpleC2S(Identifier id, NetworkCodec<T> codec) {
+		return simpleC2S(id, codec, t -> t);
+	}
+
+	Identifier getId();
+
+	NetworkSide getSide();
+
+	NetworkCodec<T> getCodec();
+
+	record Ctx(int i) implements C2SNetworkChannel.Handler {
+
+		@Override
+		public void serverHandle(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
+				PacketSender responseSender) {
+			server.sendSystemMessage(Text.of(String.valueOf(this.i)));
+		}
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/NetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/NetworkChannel.java
@@ -1,51 +1,137 @@
 package org.quiltmc.qsl.networking.api.channel;
 
 import java.util.function.Function;
+import java.util.function.Supplier;
 
-import net.minecraft.network.NetworkSide;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.network.ServerPlayNetworkHandler;
-import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
-import org.quiltmc.qsl.networking.api.PacketSender;
-import org.quiltmc.qsl.networking.api.ServerPlayNetworking;
 import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
-import org.quiltmc.qsl.networking.impl.channel.SimpleC2SNetworkChannel;
+import org.quiltmc.qsl.networking.impl.channel.NetworkChannelImpl;
 
+/**
+ * A wrapper around a NetworkCodec that allows sending, decoding and handling messages.
+ *
+ * @param <T> the type of message this channel can handle
+ */
 public interface NetworkChannel<T> {
-	C2SNetworkChannel<Ctx> CTX = NetworkChannel.simpleC2S(
-			new Identifier("test", "ctx"),
-			NetworkCodec.INT.mapInt(Ctx::i, Ctx::new)
-	);
+	/**
+	 * The event phase for when Network channels are registered.
+	 * <p/>
+	 * Registration occurs during the {@link org.quiltmc.qsl.lifecycle.api.event.ServerLifecycleEvents#READY} and
+	 * {@link org.quiltmc.qsl.lifecycle.api.client.event.ClientLifecycleEvents#READY} events.
+	 */
+	Identifier REGISTRATION_PHASE = new Identifier("quilt", "channel_registration");
 
-	static <T> SimpleC2SNetworkChannel<T> simpleC2S(Identifier id, NetworkCodec<T> codec, Function<T, C2SNetworkChannel.Handler> transform) {
-		SimpleC2SNetworkChannel<T> channel = new SimpleC2SNetworkChannel<>(id, codec, transform);
-		ServerPlayNetworking.registerGlobalReceiver(channel.id(), (server, player, handler, buf, responseSender) -> {
-			T data = channel.codec().decode(buf);
-			channel.transform().apply(data).serverHandle(server, player, handler, responseSender);
-		});
-
-		return channel;
+	/**
+	 * Create a new serverbound {@link NetworkChannel}.
+	 *
+	 * @param id              the id of the channel
+	 * @param codec           the codec used for the messages
+	 * @param handlerProvider the handler for the message
+	 * @param <T>             the type of message this channel can handle
+	 * @return the serverbound channel
+	 */
+	static <T> C2SNetworkChannel<T> createC2S(Identifier id, NetworkCodec<T> codec,
+			Supplier<Function<T, C2SNetworkChannel.Handler>> handlerProvider
+	) {
+		return NetworkChannelImpl.simpleC2S(id, codec, handlerProvider);
 	}
 
-	static <T extends C2SNetworkChannel.Handler> SimpleC2SNetworkChannel<T> simpleC2S(Identifier id, NetworkCodec<T> codec) {
-		return simpleC2S(id, codec, t -> t);
+	/**
+	 * Sorter version of {@link #createC2S(Identifier, NetworkCodec, Supplier)}.
+	 * This is a specific implementation for messages that implement the handler interface.
+	 * Using this a user doesn't need to specify the handler.
+	 *
+	 * @param id    the id of the channel
+	 * @param codec the codec used for the messages
+	 * @param <T>   the type of message this channel can handle
+	 * @return the serverbound channel
+	 * @apiNote The {@link T} type <b>must</b> implement the {@link C2SNetworkChannel.Handler} interface for this
+	 * method to work.
+	 */
+	static <T extends C2SNetworkChannel.Handler> C2SNetworkChannel<T> createC2S(Identifier id, NetworkCodec<T> codec) {
+		return NetworkChannelImpl.simpleC2S(id, codec, () -> t -> t);
 	}
 
-	Identifier getId();
-
-	NetworkSide getSide();
-
-	NetworkCodec<T> getCodec();
-
-	record Ctx(int i) implements C2SNetworkChannel.Handler {
-
-		@Override
-		public void serverHandle(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
-				PacketSender responseSender) {
-			server.sendSystemMessage(Text.of(String.valueOf(this.i)));
-		}
+	/**
+	 * Create a new clientbound {@link NetworkChannel}.
+	 *
+	 * @param id              the id of the channel
+	 * @param codec           the codec used for the messages
+	 * @param handlerProvider the handler for the message
+	 * @param <T>             the type of message this channel can handle
+	 * @return the clientbound channel
+	 */
+	static <T> S2CNetworkChannel<T> createS2C(Identifier id, NetworkCodec<T> codec,
+			Supplier<Function<T, S2CNetworkChannel.Handler>> handlerProvider
+	) {
+		return NetworkChannelImpl.simpleS2C(id, codec, handlerProvider);
 	}
+
+	/**
+	 * Sorter version of {@link #createS2C(Identifier, NetworkCodec, Supplier)}.
+	 * This is a specific implementation for messages that implement the handler interface.
+	 * Using this a user doesn't need to specify the handler.
+	 *
+	 * @param id    the id of the channel
+	 * @param codec the codec used for the messages
+	 * @param <T>   the type of message this channel can handle
+	 * @return the clientbound channel
+	 * @apiNote The {@link T} type <b>must</b> implement the {@link S2CNetworkChannel.Handler} interface for this
+	 * method to work.
+	 */
+	static <T extends S2CNetworkChannel.Handler> S2CNetworkChannel<T> createS2C(Identifier id, NetworkCodec<T> codec) {
+		return NetworkChannelImpl.simpleS2C(id, codec, () -> t -> t);
+	}
+
+	/**
+	 * Create a new {@link TwoWayNetworkChannel}.
+	 * Channels like these can send messages to both the client and the server.
+	 *
+	 * @param id                 the id of the channel
+	 * @param codec              the codec used for the messages
+	 * @param c2sHandlerProvider the handler for the message sent to the server
+	 * @param s2cHandlerProvider the handler for the message sent to the client
+	 * @param <T>                the type of message this channel can handle
+	 * @return the two-way channel
+	 */
+	static <T> TwoWayNetworkChannel<T> createTwoWay(Identifier id, NetworkCodec<T> codec,
+			Supplier<Function<T, C2SNetworkChannel.Handler>> c2sHandlerProvider,
+			Supplier<Function<T, S2CNetworkChannel.Handler>> s2cHandlerProvider
+	) {
+		return new TwoWayNetworkChannel<T>(id, codec, c2sHandlerProvider, s2cHandlerProvider);
+	}
+
+	/**
+	 * Sorter version of {@link #createTwoWay(Identifier, NetworkCodec, Supplier, Supplier)}.
+	 * This is a specific implementation for messages that implement the handler interfaces.
+	 * Using this a user doesn't need to specify the handlers for messages.
+	 *
+	 * @param id    the id of the channel
+	 * @param codec the codec used for the messages
+	 * @param <T>   the type of message this channel can handle
+	 * @return the two-way channel
+	 * @apiNote The {@link T} type <b>must</b> implement both the {@link C2SNetworkChannel.Handler} and
+	 * the {@link S2CNetworkChannel.Handler} interfaces for this method to work.
+	 */
+	static <T extends C2SNetworkChannel.Handler & S2CNetworkChannel.Handler> TwoWayNetworkChannel<T> createTwoWay(
+			Identifier id,
+			NetworkCodec<T> codec
+	) {
+		return createTwoWay(id, codec, () -> t -> t, () -> t -> t);
+	}
+
+	/**
+	 * Gets the id of the channel.
+	 *
+	 * @return the id of the channel
+	 */
+	Identifier id();
+
+	/**
+	 * Gets the codec of the channel
+	 *
+	 * @return the codec of the channel
+	 */
+	NetworkCodec<T> codec();
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/NetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/NetworkChannel.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.api.channel;
 
 import java.util.function.Function;
@@ -99,7 +115,7 @@ public interface NetworkChannel<T> {
 			Supplier<Function<T, C2SNetworkChannel.Handler>> c2sHandlerProvider,
 			Supplier<Function<T, S2CNetworkChannel.Handler>> s2cHandlerProvider
 	) {
-		return new TwoWayNetworkChannel<T>(id, codec, c2sHandlerProvider, s2cHandlerProvider);
+		return new TwoWayNetworkChannel<>(id, codec, c2sHandlerProvider, s2cHandlerProvider);
 	}
 
 	/**

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/S2CNetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/S2CNetworkChannel.java
@@ -1,0 +1,18 @@
+package org.quiltmc.qsl.networking.api.channel;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.network.NetworkSide;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+public interface S2CNetworkChannel<T> extends NetworkChannel<T> {
+	@Override
+	default NetworkSide getSide() {
+		return NetworkSide.CLIENTBOUND;
+	}
+
+	// TODO: Add environment annotation
+	interface Handler {
+		void clientHandle(MinecraftClient client, ServerPlayerEntity player, ClientPlayNetworkHandler handler);
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/S2CNetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/S2CNetworkChannel.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.api.channel;
 
 import java.util.Collection;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/S2CNetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/S2CNetworkChannel.java
@@ -1,18 +1,149 @@
 package org.quiltmc.qsl.networking.api.channel;
 
+import java.util.Collection;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
-import net.minecraft.network.NetworkSide;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
 
+import org.quiltmc.qsl.networking.api.PacketSender;
+import org.quiltmc.qsl.networking.api.PlayerLookup;
+import org.quiltmc.qsl.networking.api.ServerPlayNetworking;
+import org.quiltmc.qsl.networking.api.client.ClientPlayNetworking;
+
+/**
+ * A network channel that can send message from server to client.
+ *
+ * @param <T> the type of messages this channel can send
+ */
 public interface S2CNetworkChannel<T> extends NetworkChannel<T> {
-	@Override
-	default NetworkSide getSide() {
-		return NetworkSide.CLIENTBOUND;
+	/**
+	 * Send a message to a specific player.
+	 *
+	 * @param player  the player to send the message to
+	 * @param message the message to send
+	 */
+	default void sendToPlayer(ServerPlayerEntity player, T message) {
+		ServerPlayNetworking.send(player, this.id(), this.codec().createBuffer(message));
 	}
 
-	// TODO: Add environment annotation
+	/**
+	 * Send a message to many players.
+	 *
+	 * @param players the players to send the message to
+	 * @param message the message to send
+	 */
+	default void sendTo(Collection<ServerPlayerEntity> players, T message) {
+		ServerPlayNetworking.send(players, this.id(), this.codec().createBuffer(message));
+	}
+
+	/**
+	 * Send a message to all players that are tracking the specified {@link BlockPos}.
+	 *
+	 * @param message the message to send
+	 * @param world   the world to send the message in
+	 * @param pos     the {@link BlockPos} that a player <b>must</b> track to receive the message
+	 * @see PlayerLookup#tracking(ServerWorld, BlockPos)
+	 */
+	default void sendToTrackers(T message, ServerWorld world, BlockPos pos) {
+		this.sendTo(PlayerLookup.tracking(world, pos), message);
+	}
+
+	/**
+	 * Send a message to all players that are tracking the specified {@link BlockEntity}.
+	 *
+	 * @param message     the message to send
+	 * @param blockEntity the {@link BlockEntity} that a player <b>must</b> track to receive the message
+	 * @see PlayerLookup#tracking(BlockEntity)
+	 */
+	default void sendToTrackers(T message, BlockEntity blockEntity) {
+		this.sendTo(PlayerLookup.tracking(blockEntity), message);
+	}
+
+	/**
+	 * Send a message to all players that are tracking the specified {@link Entity}.
+	 *
+	 * @param message the message to send
+	 * @param entity  the {@link Entity} that a player <b>must</b> track to receive the message
+	 * @see PlayerLookup#tracking(Entity)
+	 */
+	default void sendToTrackers(T message, Entity entity) {
+		this.sendTo(PlayerLookup.tracking(entity), message);
+	}
+
+	/**
+	 * Send a message to all players that are tracking the chunk at the specified {@link ChunkPos}.
+	 *
+	 * @param message the message to send
+	 * @param pos     the {@link ChunkPos} of the {@link net.minecraft.world.chunk.Chunk} that a player <b>must</b>
+	 *                track to receive the message
+	 * @see PlayerLookup#tracking(ServerWorld, ChunkPos)
+	 */
+	default void sendToTrackers(T message, ServerWorld world, ChunkPos pos) {
+		this.sendTo(PlayerLookup.tracking(world, pos), message);
+	}
+
+	/**
+	 * Send a message to all players that are in the specified {@link ServerWorld}.
+	 *
+	 * @param message the message to send
+	 * @param world   the {@link ServerWorld} that a player <b>must</b> be in to receive the message
+	 * @see PlayerLookup#world(ServerWorld)
+	 */
+	default void sendToWorld(T message, ServerWorld world) {
+		this.sendTo(PlayerLookup.world(world), message);
+	}
+
+	/**
+	 * Send a message to all connected players.
+	 *
+	 * @param message the message to send
+	 * @param server  the server that the message is sent from
+	 * @see PlayerLookup#all(MinecraftServer)
+	 */
+	default void sendToAll(T message, MinecraftServer server) {
+		this.sendTo(PlayerLookup.all(server), message);
+	}
+
+	/**
+	 * Creates a {@link ClientPlayNetworking.ChannelReceiver} that uses this {@link NetworkChannel}'s
+	 * {@linkplain org.quiltmc.qsl.networking.api.codec.NetworkCodec codec} to decode messages and can handle them.
+	 *
+	 * @return a {@link ClientPlayNetworking.ChannelReceiver} that can receive messages from this
+	 * {@link NetworkChannel}
+	 */
+	@Environment(EnvType.CLIENT)
+	ClientPlayNetworking.ChannelReceiver createClientReceiver();
+
+	/**
+	 * Interface used to handle messages on the client.
+	 */
+	@FunctionalInterface
 	interface Handler {
-		void clientHandle(MinecraftClient client, ServerPlayerEntity player, ClientPlayNetworkHandler handler);
+		/**
+		 * Handle a message on the client.
+		 *
+		 * @param client         the client
+		 * @param handler        the {@link ClientPlayNetworkHandler} that received the message
+		 * @param responseSender the {@link PacketSender} to use to send responses
+		 * @apiNote This method is called on the main thread.
+		 * @implNote Always make sure implementations of this method are marked as client-only using
+		 * {@link Environment} with a value of {@link EnvType#CLIENT}.
+		 */
+		@Environment(EnvType.CLIENT)
+		void clientHandle(
+				MinecraftClient client,
+				ClientPlayNetworkHandler handler,
+				PacketSender responseSender
+		);
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/TwoWayNetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/TwoWayNetworkChannel.java
@@ -1,0 +1,90 @@
+package org.quiltmc.qsl.networking.api.channel;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+import net.minecraft.util.Identifier;
+
+import org.quiltmc.qsl.networking.api.ServerPlayNetworking;
+import org.quiltmc.qsl.networking.api.client.ClientPlayNetworking;
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+import org.quiltmc.qsl.networking.impl.channel.NetworkChannelImpl;
+
+/**
+ * A two-way network channel.
+ * This kind of channel can send messages from client to server and vice-versa.
+ * <p/>
+ * Furthermore, this channel can be used as both an {@link S2CNetworkChannel} as well as a {@link C2SNetworkChannel},
+ * for it implements the behavior of both.
+ *
+ * @param <T> The type of message that this channel can send
+ */
+public final class TwoWayNetworkChannel<T> implements S2CNetworkChannel<T>, C2SNetworkChannel<T> {
+	private final Identifier id;
+	private final NetworkCodec<T> codec;
+	/**
+	 * We can just delegate specific calls to these components, thus allowing for an easier implementation.
+	 */
+	private final C2SNetworkChannel<T> c2s;
+	private final S2CNetworkChannel<T> s2c;
+
+	/**
+	 * Creates a new two-way network channel.
+	 *
+	 * @param id                 The id of this channel
+	 * @param codec              The codec used by this channel
+	 * @param c2sHandlerProvider the handler used on the server
+	 * @param s2cHandlerProvider the handler used on the client
+	 */
+	public TwoWayNetworkChannel(
+			Identifier id,
+			NetworkCodec<T> codec,
+			Supplier<Function<T, C2SNetworkChannel.Handler>> c2sHandlerProvider,
+			Supplier<Function<T, S2CNetworkChannel.Handler>> s2cHandlerProvider
+	) {
+		this.id = id;
+		this.codec = codec;
+		this.c2s = NetworkChannelImpl.simpleC2S(id, codec, c2sHandlerProvider);
+		this.s2c = NetworkChannelImpl.simpleS2C(id, codec, s2cHandlerProvider);
+	}
+
+	/**
+	 * Gets the id of this channel.
+	 *
+	 * @return the id of this channel
+	 */
+	@Override
+	public Identifier id() {
+		return this.id;
+	}
+
+	/**
+	 * Gets the codec used by this channel.
+	 *
+	 * @return the codec used by this channel
+	 */
+	@Override
+	public NetworkCodec<T> codec() {
+		return this.codec;
+	}
+
+	/**
+	 * @see C2SNetworkChannel#createServerReceiver()
+	 */
+	@Override
+	public ServerPlayNetworking.ChannelReceiver createServerReceiver() {
+		return this.c2s.createServerReceiver();
+	}
+
+	/**
+	 * @see S2CNetworkChannel#createClientReceiver()
+	 */
+	@Environment(EnvType.CLIENT)
+	@Override
+	public ClientPlayNetworking.ChannelReceiver createClientReceiver() {
+		return this.s2c.createClientReceiver();
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/TwoWayNetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/channel/TwoWayNetworkChannel.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.api.channel;
 
 import java.util.function.Function;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/codec/NetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/codec/NetworkCodec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.api.codec;
 
 import java.time.Instant;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/codec/NetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/codec/NetworkCodec.java
@@ -1,9 +1,9 @@
 package org.quiltmc.qsl.networking.api.codec;
 
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -13,10 +13,20 @@ import com.mojang.datafixers.util.Unit;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.collection.IndexedIterable;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.Vec3f;
+import net.minecraft.util.math.Vec3i;
 
 import org.quiltmc.qsl.networking.impl.codec.ArrayNetworkCodec;
+import org.quiltmc.qsl.networking.impl.codec.EitherNetworkCodec;
+import org.quiltmc.qsl.networking.impl.codec.EnumNetworkCodec;
 import org.quiltmc.qsl.networking.impl.codec.ListNetworkCodec;
 import org.quiltmc.qsl.networking.impl.codec.MapNetworkCodec;
+import org.quiltmc.qsl.networking.impl.codec.NamedNetworkCodec;
+import org.quiltmc.qsl.networking.impl.codec.NetworkCodecBuilder;
 import org.quiltmc.qsl.networking.impl.codec.OptionalNetworkCodec;
 import org.quiltmc.qsl.networking.impl.codec.PrimitiveNetworkCodec;
 import org.quiltmc.qsl.networking.impl.codec.SimpleNetworkCodec;
@@ -32,50 +42,86 @@ public interface NetworkCodec<A> {
 	PrimitiveNetworkCodec.Short SHORT = new PrimitiveNetworkCodec.Short();
 	PrimitiveNetworkCodec.Int INT = new PrimitiveNetworkCodec.Int();
 	PrimitiveNetworkCodec.VarInt VAR_INT = new PrimitiveNetworkCodec.VarInt();
+	PrimitiveNetworkCodec.Float FLOAT = new PrimitiveNetworkCodec.Float();
 	PrimitiveNetworkCodec.Long LONG = new PrimitiveNetworkCodec.Long();
 	PrimitiveNetworkCodec.VarLong VAR_LONG = new PrimitiveNetworkCodec.VarLong();
+	PrimitiveNetworkCodec.Double DOUBLE = new PrimitiveNetworkCodec.Double();
 
-	// General
-	NetworkCodec<String> STRING = of(PacketByteBuf::writeString, PacketByteBuf::readString, "String");
-	NetworkCodec<UUID> UUID = of(PacketByteBuf::writeUuid, PacketByteBuf::readUuid, "UUID");
-	NetworkCodec<BitSet> BIT_SET = of(PacketByteBuf::writeBitSet, PacketByteBuf::readBitSet, "BitSet");
-	NetworkCodec<NbtCompound> NBT = of(PacketByteBuf::writeNbt, PacketByteBuf::readNbt, "NBT");
-	NetworkCodec<ItemStack> ITEM_STACK = of(PacketByteBuf::writeItemStack, PacketByteBuf::readItemStack, "ItemStack");
+	// Useful Java Types
+	NetworkCodec<String> STRING = of(PacketByteBuf::writeString, PacketByteBuf::readString).named("String");
+	NetworkCodec<UUID> UUID = of(PacketByteBuf::writeUuid, PacketByteBuf::readUuid).named("UUID");
+	NetworkCodec<BitSet> BIT_SET = of(PacketByteBuf::writeBitSet, PacketByteBuf::readBitSet).named("BitSet");
 
-	static <A> NetworkCodec<A> of(PacketByteBuf.Writer<A> encoder, PacketByteBuf.Reader<A> decoder, String name) {
-		return new SimpleNetworkCodec<>(encoder, decoder, name);
-	}
+	// Minecraft Types
+	NetworkCodec<NbtCompound> NBT = of(PacketByteBuf::writeNbt, PacketByteBuf::readNbt).named("NBT");
+	NetworkCodec<ItemStack> ITEM_STACK = of(PacketByteBuf::writeItemStack, PacketByteBuf::readItemStack)
+			.named("ItemStack");
+	NetworkCodec<Vec3i> VEC_3I = NetworkCodec.<Vec3i>builder().create(
+			VAR_INT.fieldOf(Vec3i::getX),
+			VAR_INT.fieldOf(Vec3i::getY),
+			VAR_INT.fieldOf(Vec3i::getZ)
+	).apply(Vec3i::new).named("Vec3i");
+	NetworkCodec<BlockPos> BLOCK_POS = of(PacketByteBuf::writeBlockPos, PacketByteBuf::readBlockPos).named("BlockPos");
+	NetworkCodec<Direction> DIRECTION = enumOf(Direction.values()).named("Direction");
+	NetworkCodec<Vec3d> VEC_3D = NetworkCodec.<Vec3d>builder().create(
+			DOUBLE.fieldOf(Vec3d::getX),
+			DOUBLE.fieldOf(Vec3d::getY),
+			DOUBLE.fieldOf(Vec3d::getZ)
+	).apply(Vec3d::new).named("Vec3d");
+	NetworkCodec<Vec3f> VEC_3F = NetworkCodec.<Vec3f>builder().create(
+			FLOAT.fieldOf(Vec3f::getX),
+			FLOAT.fieldOf(Vec3f::getY),
+			FLOAT.fieldOf(Vec3f::getZ)
+	).apply(Vec3f::new).named("Vec3f");
 
 	static <A> NetworkCodec<A> of(PacketByteBuf.Writer<A> encoder, PacketByteBuf.Reader<A> decoder) {
-		return new SimpleNetworkCodec<>(encoder, decoder, null);
+		return new SimpleNetworkCodec<>(encoder, decoder);
 	}
 
-	static <A> NetworkCodec<List<A>> listOf(NetworkCodec<A> entryCodec, IntFunction<? extends List<A>> listFactory) {
+	static <A> ListNetworkCodec<A> listOf(NetworkCodec<A> entryCodec, IntFunction<? extends List<A>> listFactory) {
 		return new ListNetworkCodec<>(entryCodec, listFactory);
 	}
 
-	static <K, V> NetworkCodec<Map<K, V>> mapOf(NetworkCodec<K> keyCodec, NetworkCodec<V> valueCodec, IntFunction<? extends Map<K, V>> mapFactory) {
-		return new MapNetworkCodec<>(entryOf(keyCodec, valueCodec), mapFactory);
+	static <K, V> MapNetworkCodec<K, V> mapOf(NetworkCodec<K> keyCodec, NetworkCodec<V> valueCodec,
+			IntFunction<? extends Map<K, V>> mapFactory) {
+		return mapOf(entryOf(keyCodec, valueCodec), mapFactory);
 	}
 
-	static <K, V> NetworkCodec<Map<K, V>> mapOf(NetworkCodec<Map.Entry<K, V>> entryCodec, IntFunction<? extends Map<K, V>> mapFactory) {
+	static <K, V> MapNetworkCodec<K, V> mapOf(NetworkCodec<Map.Entry<K, V>> entryCodec,
+			IntFunction<? extends Map<K, V>> mapFactory) {
 		return new MapNetworkCodec<>(entryCodec, mapFactory);
 	}
 
-	static <A> NetworkCodec<A[]> arrayOf(NetworkCodec<A> entryCodec, IntFunction<? extends A[]> arrayFactory) {
+	static <A> ArrayNetworkCodec<A> arrayOf(NetworkCodec<A> entryCodec, IntFunction<? extends A[]> arrayFactory) {
 		return new ArrayNetworkCodec<>(entryCodec, arrayFactory);
 	}
 
-	static <K, V> NetworkCodec<Map.Entry<K, V>> entryOf(NetworkCodec<K> keyCodec, NetworkCodec<V> valueCodec) {
+	static <K, V> MapNetworkCodec.EntryCodec<K, V> entryOf(NetworkCodec<K> keyCodec, NetworkCodec<V> valueCodec) {
 		return new MapNetworkCodec.EntryCodec<>(keyCodec, valueCodec);
 	}
 
-	static <A> NetworkCodec<Optional<A>> optionalOf(NetworkCodec<A> codec) {
+	static <A> OptionalNetworkCodec<A> optionalOf(NetworkCodec<A> codec) {
 		return new OptionalNetworkCodec<>(codec);
 	}
 
+	static <A> NetworkCodec<A> indexOf(IndexedIterable<A> idxIter) {
+		return VAR_INT.mapInt(idxIter::getRawId, idxIter::get).named("IndexOf[%s]".formatted(idxIter));
+	}
+
+	static <A, B> EitherNetworkCodec<A, B> eitherOf(NetworkCodec<A> leftCodec, NetworkCodec<B> rightCodec) {
+		return new EitherNetworkCodec<>(leftCodec, rightCodec);
+	}
+
 	static <A> NetworkCodec<A> constant(A value) {
-		return of((buf, a) -> {}, (buf) -> value, "Constant[" + value + "]");
+		return of((buf, a) -> { }, (buf) -> value).named("Constant[%s]".formatted(value));
+	}
+
+	static <A extends Enum<A>> EnumNetworkCodec<A> enumOf(A[] values) {
+		return new EnumNetworkCodec<>(values);
+	}
+
+	static <A> NetworkCodecBuilder<A> builder() {
+		return new NetworkCodecBuilder<>();
 	}
 
 	A decode(PacketByteBuf buf);
@@ -90,10 +136,30 @@ public interface NetworkCodec<A> {
 		return this::encode;
 	}
 
+	default OptionalNetworkCodec<A> optional() {
+		return optionalOf(this);
+	}
+
+	default ListNetworkCodec<A> list() {
+		return listOf(this, ArrayList::new);
+	}
+
+	default <V> MapNetworkCodec.EntryCodec<A, V> zip(NetworkCodec<V> valueCodec) {
+		return entryOf(this, valueCodec);
+	}
+
 	default <B> NetworkCodec<B> map(Function<? super B, ? extends A> from, Function<? super A, ? extends B> to) {
-		return new SimpleNetworkCodec<>(
-				(byteBuf, data) -> this.encode(byteBuf, from.apply(data)), byteBuf -> to.apply(this.decode(byteBuf)),
-				this + "[mapped]"
-		);
+		return new SimpleNetworkCodec<B>(
+				(byteBuf, data) -> this.encode(byteBuf, from.apply(data)),
+				byteBuf -> to.apply(this.decode(byteBuf))
+		).named(this + "[mapped]");
+	}
+
+	default <T> NetworkCodecBuilder.Field<T, A> fieldOf(Function<? super T, ? extends A> fieldLocator) {
+		return new NetworkCodecBuilder.Field<>(this, fieldLocator);
+	}
+
+	default NamedNetworkCodec<A> named(String name) {
+		return new NamedNetworkCodec<>(name, this);
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/codec/NetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/api/codec/NetworkCodec.java
@@ -1,0 +1,91 @@
+package org.quiltmc.qsl.networking.api.codec;
+
+import java.util.BitSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.impl.codec.ArrayNetworkCodec;
+import org.quiltmc.qsl.networking.impl.codec.ListNetworkCodec;
+import org.quiltmc.qsl.networking.impl.codec.MapNetworkCodec;
+import org.quiltmc.qsl.networking.impl.codec.OptionalNetworkCodec;
+import org.quiltmc.qsl.networking.impl.codec.PrimitiveNetworkCodec;
+import org.quiltmc.qsl.networking.impl.codec.SimpleNetworkCodec;
+
+public interface NetworkCodec<A> {
+	// Java Primitives
+	PrimitiveNetworkCodec.Boolean BOOLEAN = new PrimitiveNetworkCodec.Boolean();
+	PrimitiveNetworkCodec.Byte BYTE = new PrimitiveNetworkCodec.Byte();
+	PrimitiveNetworkCodec.Char CHAR = new PrimitiveNetworkCodec.Char();
+	PrimitiveNetworkCodec.Short SHORT = new PrimitiveNetworkCodec.Short();
+	PrimitiveNetworkCodec.Int INT = new PrimitiveNetworkCodec.Int();
+	PrimitiveNetworkCodec.VarInt VAR_INT = new PrimitiveNetworkCodec.VarInt();
+	PrimitiveNetworkCodec.Long LONG = new PrimitiveNetworkCodec.Long();
+	PrimitiveNetworkCodec.VarLong VAR_LONG = new PrimitiveNetworkCodec.VarLong();
+
+	// General
+	NetworkCodec<String> STRING = of(PacketByteBuf::readString, PacketByteBuf::writeString, "String");
+	NetworkCodec<UUID> UUID = of(PacketByteBuf::readUuid, PacketByteBuf::writeUuid, "UUID");
+	NetworkCodec<BitSet> BIT_SET = of(PacketByteBuf::readBitSet, PacketByteBuf::writeBitSet, "BitSet");
+	NetworkCodec<NbtCompound> NBT = of(PacketByteBuf::readNbt, PacketByteBuf::writeNbt, "NBT");
+	NetworkCodec<ItemStack> ITEM_STACK = of(PacketByteBuf::readItemStack, PacketByteBuf::writeItemStack, "ItemStack");
+
+	static <A> NetworkCodec<A> of(PacketByteBuf.Reader<A> decoder, PacketByteBuf.Writer<A> encoder, String name) {
+		return new SimpleNetworkCodec<>(decoder, encoder, name);
+	}
+
+	static <A> NetworkCodec<A> of(PacketByteBuf.Reader<A> decoder, PacketByteBuf.Writer<A> encoder) {
+		return new SimpleNetworkCodec<>(decoder, encoder, null);
+	}
+
+	static <A> NetworkCodec<List<A>> listOf(NetworkCodec<A> entryCodec, IntFunction<? extends List<A>> listFactory) {
+		return new ListNetworkCodec<>(entryCodec, listFactory);
+	}
+
+	static <K, V> NetworkCodec<Map<K, V>> mapOf(NetworkCodec<K> keyCodec, NetworkCodec<V> valueCodec, IntFunction<? extends Map<K, V>> mapFactory) {
+		return new MapNetworkCodec<>(keyCodec, valueCodec, mapFactory);
+	}
+
+	static <K, V> NetworkCodec<Map<K, V>> mapOf(NetworkCodec<Map.Entry<K, V>> entryCodec, IntFunction<? extends Map<K, V>> mapFactory) {
+		return new MapNetworkCodec<>(entryCodec, mapFactory);
+	}
+
+	static <A> NetworkCodec<A[]> arrayOf(NetworkCodec<A> entryCodec, IntFunction<? extends A[]> arrayFactory) {
+		return new ArrayNetworkCodec<>(entryCodec, arrayFactory);
+	}
+
+	static <K, V> NetworkCodec<Map.Entry<K, V>> entryOf(NetworkCodec<K> keyCodec, NetworkCodec<V> valueCodec) {
+		return new MapNetworkCodec.EntryCodec<>(keyCodec, valueCodec);
+	}
+
+	static <A> NetworkCodec<Optional<A>> optionalOf(NetworkCodec<A> codec) {
+		return new OptionalNetworkCodec<>(codec);
+	}
+
+	A decode(PacketByteBuf buf);
+
+	void encode(PacketByteBuf buf, A data);
+
+	default PacketByteBuf.Reader<A> asReader() {
+		return this::decode;
+	}
+
+	default PacketByteBuf.Writer<A> asWriter() {
+		return this::encode;
+	}
+
+	default <B> NetworkCodec<B> map(Function<? super B, ? extends A> from, Function<? super A, ? extends B> to) {
+		return new SimpleNetworkCodec<>(
+				byteBuf -> to.apply(this.decode(byteBuf)),
+				(byteBuf, data) -> this.encode(byteBuf, from.apply(data)),
+				this + "[mapped]"
+		);
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/NetworkingImpl.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/NetworkingImpl.java
@@ -30,11 +30,14 @@ import net.minecraft.server.network.ServerLoginNetworkHandler;
 import net.minecraft.util.Identifier;
 
 import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.qsl.lifecycle.api.event.ServerLifecycleEvents;
 import org.quiltmc.qsl.networking.api.PacketByteBufs;
 import org.quiltmc.qsl.networking.api.PacketSender;
 import org.quiltmc.qsl.networking.api.ServerLoginConnectionEvents;
 import org.quiltmc.qsl.networking.api.ServerLoginNetworking;
 import org.quiltmc.qsl.networking.api.ServerPlayNetworking;
+import org.quiltmc.qsl.networking.api.channel.NetworkChannel;
+import org.quiltmc.qsl.networking.impl.channel.NetworkChannelImpl;
 
 @ApiStatus.Internal
 public final class NetworkingImpl {
@@ -80,6 +83,9 @@ public final class NetworkingImpl {
 
 		ServerLoginNetworking.registerGlobalReceiver(EARLY_REGISTRATION_CHANNEL, NetworkingImpl::receiveEarlyRegistration);
 		ServerLoginNetworking.registerGlobalReceiver(EARLY_REGISTRATION_CHANNEL_FABRIC, NetworkingImpl::receiveEarlyRegistration);
+
+		// Register Common Channels
+		ServerLifecycleEvents.READY.register(NetworkChannel.REGISTRATION_PHASE, NetworkChannelImpl::onServerReady);
 	}
 
 	public static boolean isReservedPlayChannel(Identifier channelName) {

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/NetworkChannelImpl.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/NetworkChannelImpl.java
@@ -1,0 +1,51 @@
+package org.quiltmc.qsl.networking.impl.channel;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.google.common.base.Suppliers;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import org.jetbrains.annotations.ApiStatus;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.Identifier;
+
+import org.quiltmc.qsl.networking.api.ServerPlayNetworking;
+import org.quiltmc.qsl.networking.api.channel.C2SNetworkChannel;
+import org.quiltmc.qsl.networking.api.channel.S2CNetworkChannel;
+import org.quiltmc.qsl.networking.api.client.ClientPlayNetworking;
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+@ApiStatus.Internal
+public final class NetworkChannelImpl {
+	private static final List<C2SNetworkChannel<?>> C2S = new ArrayList<>();
+	private static final List<S2CNetworkChannel<?>> S2C = new ArrayList<>();
+
+	public static <T> C2SNetworkChannel<T> simpleC2S(Identifier id, NetworkCodec<T> codec, Supplier<Function<T, C2SNetworkChannel.Handler>> handlerProvider) {
+		Supplier<Function<T, C2SNetworkChannel.Handler>> memoizedHandler = Suppliers.memoize(handlerProvider::get);
+		SimpleC2SNetworkChannel<T> channel = new SimpleC2SNetworkChannel<>(id, codec, memoizedHandler);
+		C2S.add(channel);
+		return channel;
+	}
+
+	public static <T> S2CNetworkChannel<T> simpleS2C(Identifier id, NetworkCodec<T> codec, Supplier<Function<T, S2CNetworkChannel.Handler>> handlerProvider) {
+		Supplier<Function<T, S2CNetworkChannel.Handler>> memoizedHandler = Suppliers.memoize(handlerProvider::get);
+		S2CNetworkChannel<T> channel = new SimpleS2CNetworkChannel<>(id, codec, memoizedHandler);
+		S2C.add(channel);
+		return channel;
+	}
+
+	// TODO: Register these events!
+	public static void onServerReady(MinecraftServer ignored) {
+		C2S.forEach(channel -> ServerPlayNetworking.registerGlobalReceiver(channel.id(), channel.createServerReceiver()));
+	}
+
+	@Environment(EnvType.CLIENT)
+	public static void onClientReady(MinecraftClient ignored) {
+		S2C.forEach(channel -> ClientPlayNetworking.registerGlobalReceiver(channel.id(), channel.createClientReceiver()));
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/NetworkChannelImpl.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/NetworkChannelImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.channel;
 
 import java.util.ArrayList;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/SimpleC2SNetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/SimpleC2SNetworkChannel.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.channel;
 
 import java.util.function.Function;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/SimpleC2SNetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/SimpleC2SNetworkChannel.java
@@ -1,0 +1,24 @@
+package org.quiltmc.qsl.networking.impl.channel;
+
+import java.util.function.Function;
+
+import net.minecraft.util.Identifier;
+
+import org.quiltmc.qsl.networking.api.channel.C2SNetworkChannel;
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public record SimpleC2SNetworkChannel<T>(
+		Identifier id,
+		NetworkCodec<T> codec,
+		Function<T, Handler> transform
+) implements C2SNetworkChannel<T> {
+	@Override
+	public Identifier getId() {
+		return this.id;
+	}
+
+	@Override
+	public NetworkCodec<T> getCodec() {
+		return this.codec;
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/SimpleC2SNetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/SimpleC2SNetworkChannel.java
@@ -1,24 +1,24 @@
 package org.quiltmc.qsl.networking.impl.channel;
 
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import net.minecraft.util.Identifier;
 
+import org.quiltmc.qsl.networking.api.ServerPlayNetworking;
 import org.quiltmc.qsl.networking.api.channel.C2SNetworkChannel;
 import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
 
 public record SimpleC2SNetworkChannel<T>(
 		Identifier id,
 		NetworkCodec<T> codec,
-		Function<T, Handler> transform
+		Supplier<Function<T, C2SNetworkChannel.Handler>> handlerProvider
 ) implements C2SNetworkChannel<T> {
 	@Override
-	public Identifier getId() {
-		return this.id;
-	}
-
-	@Override
-	public NetworkCodec<T> getCodec() {
-		return this.codec;
+	public ServerPlayNetworking.ChannelReceiver createServerReceiver() {
+		return (server, player, handler, buf, responseSender) -> {
+			T message = this.codec.decode(buf);
+			server.execute(() -> this.handlerProvider.get().apply(message).serverHandle(server, player, handler, responseSender));
+		};
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/SimpleS2CNetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/SimpleS2CNetworkChannel.java
@@ -1,0 +1,24 @@
+package org.quiltmc.qsl.networking.impl.channel;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import net.minecraft.util.Identifier;
+
+import org.quiltmc.qsl.networking.api.channel.S2CNetworkChannel;
+import org.quiltmc.qsl.networking.api.client.ClientPlayNetworking;
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public record SimpleS2CNetworkChannel<T>(
+		Identifier id,
+		NetworkCodec<T> codec,
+		Supplier<Function<T, S2CNetworkChannel.Handler>> handlerProvider
+) implements S2CNetworkChannel<T> {
+	@Override
+	public ClientPlayNetworking.ChannelReceiver createClientReceiver() {
+		return (client, handler, buf, responseSender) -> {
+			T message = this.codec.decode(buf);
+			client.execute(() -> this.handlerProvider.get().apply(message).clientHandle(client, handler, responseSender));
+		};
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/SimpleS2CNetworkChannel.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/channel/SimpleS2CNetworkChannel.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.channel;
 
 import java.util.function.Function;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/client/ClientNetworkingImpl.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/client/ClientNetworkingImpl.java
@@ -38,7 +38,9 @@ import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
 import net.minecraft.util.Identifier;
 
 import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.qsl.lifecycle.api.client.event.ClientLifecycleEvents;
 import org.quiltmc.qsl.networking.api.PacketByteBufs;
+import org.quiltmc.qsl.networking.api.channel.NetworkChannel;
 import org.quiltmc.qsl.networking.api.client.ClientLoginNetworking;
 import org.quiltmc.qsl.networking.api.client.ClientPlayConnectionEvents;
 import org.quiltmc.qsl.networking.api.client.ClientPlayNetworking;
@@ -46,6 +48,7 @@ import org.quiltmc.qsl.networking.impl.ChannelInfoHolder;
 import org.quiltmc.qsl.networking.impl.GlobalReceiverRegistry;
 import org.quiltmc.qsl.networking.impl.NetworkHandlerExtensions;
 import org.quiltmc.qsl.networking.impl.NetworkingImpl;
+import org.quiltmc.qsl.networking.impl.channel.NetworkChannelImpl;
 import org.quiltmc.qsl.networking.mixin.accessor.ConnectScreenAccessor;
 import org.quiltmc.qsl.networking.mixin.accessor.MinecraftClientAccessor;
 
@@ -121,6 +124,9 @@ public final class ClientNetworkingImpl {
 		// Register a login query handler for early channel registration.
 		ClientLoginNetworking.registerGlobalReceiver(NetworkingImpl.EARLY_REGISTRATION_CHANNEL, ClientNetworkingImpl::receiveEarlyRegistration);
 		ClientLoginNetworking.registerGlobalReceiver(NetworkingImpl.EARLY_REGISTRATION_CHANNEL_FABRIC, ClientNetworkingImpl::receiveEarlyRegistration);
+
+		// Register Channels
+		ClientLifecycleEvents.READY.register(NetworkChannel.REGISTRATION_PHASE, NetworkChannelImpl::onClientReady);
 	}
 
 	private static CompletableFuture<PacketByteBuf> receiveEarlyRegistration(MinecraftClient client, ClientLoginNetworkHandler handler, PacketByteBuf buf,

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/ArrayNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/ArrayNetworkCodec.java
@@ -1,0 +1,43 @@
+package org.quiltmc.qsl.networking.impl.codec;
+
+import java.util.function.IntFunction;
+
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public class ArrayNetworkCodec<A> implements NetworkCodec<A[]> {
+	private final NetworkCodec<A> entryCodec;
+	private final IntFunction<? extends A[]> arrayFactory;
+
+	public ArrayNetworkCodec(NetworkCodec<A> entryCodec, IntFunction<? extends A[]> arrayFactory) {
+		this.entryCodec = entryCodec;
+		this.arrayFactory = arrayFactory;
+	}
+
+	@Override
+	public A[] decode(PacketByteBuf buf) {
+		int size = buf.readVarInt();
+		A[] array = this.arrayFactory.apply(size);
+
+		for (int i = 0; i < size; i++) {
+			array[i] = this.entryCodec.decode(buf);
+		}
+
+		return array;
+	}
+
+	@Override
+	public void encode(PacketByteBuf buf, A[] data) {
+		buf.writeVarInt(data.length);
+
+		for (A entry : data) {
+			this.entryCodec.encode(buf, entry);
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "ArrayNetworkCodec[" + this.entryCodec + "]";
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/ArrayNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/ArrayNetworkCodec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.codec;
 
 import java.util.function.Consumer;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/ArrayNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/ArrayNetworkCodec.java
@@ -1,5 +1,6 @@
 package org.quiltmc.qsl.networking.impl.codec;
 
+import java.util.function.Consumer;
 import java.util.function.IntFunction;
 
 import net.minecraft.network.PacketByteBuf;
@@ -36,8 +37,16 @@ public class ArrayNetworkCodec<A> implements NetworkCodec<A[]> {
 		}
 	}
 
+	public void forEach(PacketByteBuf buf, Consumer<? super A> action) {
+		int size = buf.readVarInt();
+
+		for (int i = 0; i < size; i++) {
+			action.accept(this.entryCodec.decode(buf));
+		}
+	}
+
 	@Override
 	public String toString() {
-		return "ArrayNetworkCodec[" + this.entryCodec + "]";
+		return "ArrayNetworkCodec[%s]".formatted(this.entryCodec);
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/CollectionNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/CollectionNetworkCodec.java
@@ -1,44 +1,14 @@
 package org.quiltmc.qsl.networking.impl.codec;
 
 import java.util.Collection;
-import java.util.function.IntFunction;
+import java.util.function.Consumer;
 
 import net.minecraft.network.PacketByteBuf;
 
 import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
 
-public class CollectionNetworkCodec<A> implements NetworkCodec<Collection<A>> {
-	private final NetworkCodec<A> entryCodec;
-	private final IntFunction<? extends Collection<A>> collectionFactory;
+public interface CollectionNetworkCodec<A, C extends Collection<A>> extends NetworkCodec<C> {
+	NetworkCodec<A> getEntryCodec();
 
-	public CollectionNetworkCodec(NetworkCodec<A> entryCodec, IntFunction<? extends Collection<A>> collectionFactory) {
-		this.entryCodec = entryCodec;
-		this.collectionFactory = collectionFactory;
-	}
-
-	@Override
-	public Collection<A> decode(PacketByteBuf buf) {
-		int size = buf.readVarInt();
-		Collection<A> collection = this.collectionFactory.apply(size);
-
-		for (int i = 0; i < size; i++) {
-			collection.add(this.entryCodec.decode(buf));
-		}
-
-		return collection;
-	}
-
-	@Override
-	public void encode(PacketByteBuf buf, Collection<A> data) {
-		buf.writeVarInt(data.size());
-
-		for (A entry : data) {
-			this.entryCodec.encode(buf, entry);
-		}
-	}
-
-	@Override
-	public String toString() {
-		return "CollectionNetworkCodec[" + this.entryCodec + "]";
-	}
+	void forEach(PacketByteBuf buf, Consumer<? super A> action);
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/CollectionNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/CollectionNetworkCodec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.codec;
 
 import java.util.Collection;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/CollectionNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/CollectionNetworkCodec.java
@@ -1,0 +1,44 @@
+package org.quiltmc.qsl.networking.impl.codec;
+
+import java.util.Collection;
+import java.util.function.IntFunction;
+
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public class CollectionNetworkCodec<A> implements NetworkCodec<Collection<A>> {
+	private final NetworkCodec<A> entryCodec;
+	private final IntFunction<? extends Collection<A>> collectionFactory;
+
+	public CollectionNetworkCodec(NetworkCodec<A> entryCodec, IntFunction<? extends Collection<A>> collectionFactory) {
+		this.entryCodec = entryCodec;
+		this.collectionFactory = collectionFactory;
+	}
+
+	@Override
+	public Collection<A> decode(PacketByteBuf buf) {
+		int size = buf.readVarInt();
+		Collection<A> collection = this.collectionFactory.apply(size);
+
+		for (int i = 0; i < size; i++) {
+			collection.add(this.entryCodec.decode(buf));
+		}
+
+		return collection;
+	}
+
+	@Override
+	public void encode(PacketByteBuf buf, Collection<A> data) {
+		buf.writeVarInt(data.size());
+
+		for (A entry : data) {
+			this.entryCodec.encode(buf, entry);
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "CollectionNetworkCodec[" + this.entryCodec + "]";
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/DispatchedNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/DispatchedNetworkCodec.java
@@ -1,0 +1,38 @@
+package org.quiltmc.qsl.networking.impl.codec;
+
+import java.util.function.Function;
+
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public class DispatchedNetworkCodec<T, P> implements NetworkCodec<T> {
+	private final NetworkCodec<P> parent;
+	private final Function<? super T, P> transformer;
+	private final Function<? super P, NetworkCodec<T>> dispatch;
+
+	public DispatchedNetworkCodec(NetworkCodec<P> parent,
+			Function<? super T, P> transformer,
+			Function<? super P, NetworkCodec<T>> dispatch) {
+		this.parent = parent;
+		this.transformer = transformer;
+		this.dispatch = dispatch;
+	}
+
+	@Override
+	public T decode(PacketByteBuf buf) {
+		return this.dispatch.apply(this.parent.decode(buf)).decode(buf);
+	}
+
+	@Override
+	public void encode(PacketByteBuf buf, T data) {
+		P pState = this.transformer.apply(data);
+		this.parent.encode(buf, pState);
+		this.dispatch.apply(pState).encode(buf, data);
+	}
+
+	@Override
+	public String toString() {
+		return "DispatchFrom[%s]".formatted(this.parent);
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/DispatchedNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/DispatchedNetworkCodec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.codec;
 
 import java.util.function.Function;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EitherNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EitherNetworkCodec.java
@@ -1,0 +1,44 @@
+package org.quiltmc.qsl.networking.impl.codec;
+
+import com.mojang.datafixers.util.Either;
+
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public class EitherNetworkCodec<A, B> implements NetworkCodec<Either<A, B>> {
+	private final NetworkCodec<A> leftCodec;
+	private final NetworkCodec<B> rightCodec;
+
+	public EitherNetworkCodec(NetworkCodec<A> leftCodec, NetworkCodec<B> rightCodec) {
+		this.leftCodec = leftCodec;
+		this.rightCodec = rightCodec;
+	}
+
+	@Override
+	public Either<A, B> decode(PacketByteBuf buf) {
+		boolean isRight = buf.readBoolean();
+
+		if (isRight) {
+			return Either.right(this.rightCodec.decode(buf));
+		} else {
+			return Either.left(this.leftCodec.decode(buf));
+		}
+	}
+
+	@Override
+	public void encode(PacketByteBuf buf, Either<A, B> data) {
+		data.ifLeft(a -> {
+			buf.writeBoolean(false);
+			this.leftCodec.encode(buf, a);
+		}).ifRight(b -> {
+			buf.writeBoolean(true);
+			this.rightCodec.encode(buf, b);
+		});
+	}
+
+	@Override
+	public String toString() {
+		return "EitherNetworkCodec[" + this.leftCodec + ", " + this.rightCodec + "]";
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EitherNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EitherNetworkCodec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.codec;
 
 import com.mojang.datafixers.util.Either;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EitherNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EitherNetworkCodec.java
@@ -39,6 +39,6 @@ public class EitherNetworkCodec<A, B> implements NetworkCodec<Either<A, B>> {
 
 	@Override
 	public String toString() {
-		return "EitherNetworkCodec[" + this.leftCodec + ", " + this.rightCodec + "]";
+		return "EitherNetworkCodec[%s, %s]".formatted(this.leftCodec, this.rightCodec);
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EnumNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EnumNetworkCodec.java
@@ -6,9 +6,11 @@ import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
 
 public class EnumNetworkCodec<A extends Enum<A>> implements NetworkCodec<A> {
 	private final A[] values;
+	private final String className;
 
 	public EnumNetworkCodec(A[] values) {
 		this.values = values;
+		this.className = this.values.length > 0 ? this.values[0].getClass().getName() : "";
 	}
 
 	@Override
@@ -19,5 +21,10 @@ public class EnumNetworkCodec<A extends Enum<A>> implements NetworkCodec<A> {
 	@Override
 	public void encode(PacketByteBuf buf, A data) {
 		buf.writeVarInt(data.ordinal());
+	}
+
+	@Override
+	public String toString() {
+		return this.className;
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EnumNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EnumNetworkCodec.java
@@ -1,0 +1,23 @@
+package org.quiltmc.qsl.networking.impl.codec;
+
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public class EnumNetworkCodec<A extends Enum<A>> implements NetworkCodec<A> {
+	private final A[] values;
+
+	public EnumNetworkCodec(A[] values) {
+		this.values = values;
+	}
+
+	@Override
+	public A decode(PacketByteBuf buf) {
+		return this.values[buf.readVarInt()];
+	}
+
+	@Override
+	public void encode(PacketByteBuf buf, A data) {
+		buf.writeVarInt(data.ordinal());
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EnumNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EnumNetworkCodec.java
@@ -5,12 +5,12 @@ import net.minecraft.network.PacketByteBuf;
 import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
 
 public class EnumNetworkCodec<A extends Enum<A>> implements NetworkCodec<A> {
+	private final Class<A> clazz;
 	private final A[] values;
-	private final String className;
 
-	public EnumNetworkCodec(A[] values) {
-		this.values = values;
-		this.className = this.values.getClass().getComponentType().getSimpleName();
+	public EnumNetworkCodec(Class<A> clazz) {
+		this.clazz = clazz;
+		this.values = clazz.getEnumConstants();
 	}
 
 	@Override
@@ -25,6 +25,6 @@ public class EnumNetworkCodec<A extends Enum<A>> implements NetworkCodec<A> {
 
 	@Override
 	public String toString() {
-		return this.className;
+		return this.clazz.getSimpleName();
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EnumNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EnumNetworkCodec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.codec;
 
 import net.minecraft.network.PacketByteBuf;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EnumNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/EnumNetworkCodec.java
@@ -10,7 +10,7 @@ public class EnumNetworkCodec<A extends Enum<A>> implements NetworkCodec<A> {
 
 	public EnumNetworkCodec(A[] values) {
 		this.values = values;
-		this.className = this.values.length > 0 ? this.values[0].getClass().getName() : "";
+		this.className = this.values.getClass().getComponentType().getSimpleName();
 	}
 
 	@Override

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/ListNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/ListNetworkCodec.java
@@ -1,0 +1,44 @@
+package org.quiltmc.qsl.networking.impl.codec;
+
+import java.util.List;
+import java.util.function.IntFunction;
+
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public class ListNetworkCodec<A> implements NetworkCodec<List<A>> {
+	private final NetworkCodec<A> entryCodec;
+	private final IntFunction<? extends List<A>> listFactory;
+
+	public ListNetworkCodec(NetworkCodec<A> entryCodec, IntFunction<? extends List<A>> listFactory) {
+		this.entryCodec = entryCodec;
+		this.listFactory = listFactory;
+	}
+
+	@Override
+	public List<A> decode(PacketByteBuf buf) {
+		int size = buf.readVarInt();
+		List<A> list = this.listFactory.apply(size);
+
+		for (int i = 0; i < size; i++) {
+			list.add(this.entryCodec.decode(buf));
+		}
+
+		return list;
+	}
+
+	@Override
+	public void encode(PacketByteBuf buf, List<A> data) {
+		buf.writeVarInt(data.size());
+
+		for (A entry : data) {
+			this.entryCodec.encode(buf, entry);
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "ListNetworkCodec[" + this.entryCodec + "]";
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/ListNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/ListNetworkCodec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.codec;
 
 import java.util.List;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/ListNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/ListNetworkCodec.java
@@ -1,13 +1,14 @@
 package org.quiltmc.qsl.networking.impl.codec;
 
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.IntFunction;
 
 import net.minecraft.network.PacketByteBuf;
 
 import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
 
-public class ListNetworkCodec<A> implements NetworkCodec<List<A>> {
+public class ListNetworkCodec<A> implements CollectionNetworkCodec<A, List<A>> {
 	private final NetworkCodec<A> entryCodec;
 	private final IntFunction<? extends List<A>> listFactory;
 
@@ -39,6 +40,20 @@ public class ListNetworkCodec<A> implements NetworkCodec<List<A>> {
 
 	@Override
 	public String toString() {
-		return "ListNetworkCodec[" + this.entryCodec + "]";
+		return "ListNetworkCodec[%s]".formatted(this.entryCodec);
+	}
+
+	@Override
+	public NetworkCodec<A> getEntryCodec() {
+		return this.entryCodec;
+	}
+
+	@Override
+	public void forEach(PacketByteBuf buf, Consumer<? super A> action) {
+		int size = buf.readVarInt();
+
+		for (int i = 0; i < size; i++) {
+			action.accept(this.entryCodec.decode(buf));
+		}
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/MapNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/MapNetworkCodec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.codec;
 
 import java.util.HashMap;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/MapNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/MapNetworkCodec.java
@@ -1,0 +1,93 @@
+package org.quiltmc.qsl.networking.impl.codec;
+
+import java.util.Map;
+import java.util.function.IntFunction;
+
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public class MapNetworkCodec<K, V> implements NetworkCodec<Map<K, V>> {
+	private final NetworkCodec<Map.Entry<K, V>> entryCodec;
+	private final IntFunction<? extends Map<K, V>> mapFactory;
+
+	public MapNetworkCodec(NetworkCodec<K> keyCodec, NetworkCodec<V> valueCodec, IntFunction<? extends Map<K, V>> mapFactory) {
+		this(new EntryCodec<>(keyCodec, valueCodec), mapFactory);
+	}
+
+	public MapNetworkCodec(NetworkCodec<Map.Entry<K, V> > entryCodec, IntFunction<? extends Map<K, V>> mapFactory) {
+		this.entryCodec = entryCodec;
+		this.mapFactory = mapFactory;
+	}
+
+	@Override
+	public Map<K, V> decode(PacketByteBuf buf) {
+		int size = buf.readVarInt();
+		Map<K, V> map = this.mapFactory.apply(size);
+
+		for (int i = 0; i < size; i++) {
+			Map.Entry<K, V> entry = this.entryCodec.decode(buf);
+			map.put(entry.getKey(), entry.getValue());
+		}
+
+		return map;
+	}
+
+	@Override
+	public void encode(PacketByteBuf buf, Map<K, V> data) {
+		buf.writeVarInt(data.size());
+
+		for (Map.Entry<K, V> entry : data.entrySet()) {
+			this.entryCodec.encode(buf, entry);
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "MapNetworkCodec[" + this.entryCodec + "]";
+	}
+
+	public static class EntryCodec<K, V> implements NetworkCodec<Map.Entry<K, V>> {
+		private final NetworkCodec<K> keyCodec;
+		private final NetworkCodec<V> valueCodec;
+
+		public EntryCodec(NetworkCodec<K> keyCodec, NetworkCodec<V> valueCodec) {
+			this.keyCodec = keyCodec;
+			this.valueCodec = valueCodec;
+		}
+
+		@Override
+		public Map.Entry<K, V> decode(PacketByteBuf buf) {
+			K key = this.keyCodec.decode(buf);
+			V value = this.valueCodec.decode(buf);
+
+			return new Map.Entry<>() {
+				@Override
+				public K getKey() {
+					return key;
+				}
+
+				@Override
+				public V getValue() {
+					return value;
+				}
+
+				@Override
+				public V setValue(V value) {
+					throw new UnsupportedOperationException();
+				}
+			};
+		}
+
+		@Override
+		public void encode(PacketByteBuf buf, Map.Entry<K, V> data) {
+			this.keyCodec.encode(buf, data.getKey());
+			this.valueCodec.encode(buf, data.getValue());
+		}
+
+		@Override
+		public String toString() {
+			return "EntryCodec{keyCodec=" + this.keyCodec + ", valueCodec=" + this.valueCodec + '}';
+		}
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/MapNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/MapNetworkCodec.java
@@ -98,8 +98,8 @@ public class MapNetworkCodec<K, V> implements NetworkCodec<Map<K, V>> {
 			return this.intoMap(HashMap::new);
 		}
 
-		public MapNetworkCodec<K, V> intoMap(IntFunction<Map<K ,V>> mapFactory) {
-			return NetworkCodec.mapOf(this, mapFactory);
+		public MapNetworkCodec<K, V> intoMap(IntFunction<? extends Map<K ,V>> mapFactory) {
+			return new MapNetworkCodec<>(this, mapFactory);
 		}
 
 		public PairNetworkCodec<K ,V> intoPair() {

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/MapNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/MapNetworkCodec.java
@@ -1,5 +1,6 @@
 package org.quiltmc.qsl.networking.impl.codec;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.IntFunction;
 
@@ -79,6 +80,14 @@ public class MapNetworkCodec<K, V> implements NetworkCodec<Map<K, V>> {
 		public void encode(PacketByteBuf buf, Map.Entry<K, V> data) {
 			this.keyCodec.encode(buf, data.getKey());
 			this.valueCodec.encode(buf, data.getValue());
+		}
+
+		public MapNetworkCodec<K, V> intoMap() {
+			return this.intoMap(HashMap::new);
+		}
+
+		public MapNetworkCodec<K, V> intoMap(IntFunction<Map<K ,V>> mapFactory) {
+			return NetworkCodec.mapOf(this, mapFactory);
 		}
 
 		@Override

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/MapNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/MapNetworkCodec.java
@@ -11,10 +11,6 @@ public class MapNetworkCodec<K, V> implements NetworkCodec<Map<K, V>> {
 	private final NetworkCodec<Map.Entry<K, V>> entryCodec;
 	private final IntFunction<? extends Map<K, V>> mapFactory;
 
-	public MapNetworkCodec(NetworkCodec<K> keyCodec, NetworkCodec<V> valueCodec, IntFunction<? extends Map<K, V>> mapFactory) {
-		this(new EntryCodec<>(keyCodec, valueCodec), mapFactory);
-	}
-
 	public MapNetworkCodec(NetworkCodec<Map.Entry<K, V> > entryCodec, IntFunction<? extends Map<K, V>> mapFactory) {
 		this.entryCodec = entryCodec;
 		this.mapFactory = mapFactory;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NamedNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NamedNetworkCodec.java
@@ -1,0 +1,30 @@
+package org.quiltmc.qsl.networking.impl.codec;
+
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public class NamedNetworkCodec<A> implements NetworkCodec<A> {
+	private final String name;
+	private final NetworkCodec<A> delegate;
+
+	public NamedNetworkCodec(String name, NetworkCodec<A> delegate) {
+		this.name = name;
+		this.delegate = delegate;
+	}
+
+	@Override
+	public A decode(PacketByteBuf buf) {
+		return this.delegate.decode(buf);
+	}
+
+	@Override
+	public void encode(PacketByteBuf buf, A data) {
+		this.delegate.encode(buf, data);
+	}
+
+	@Override
+	public String toString() {
+		return "%s(%s)".formatted(this.name, this.delegate);
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NamedNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NamedNetworkCodec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.codec;
 
 import net.minecraft.network.PacketByteBuf;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NamedNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NamedNetworkCodec.java
@@ -25,6 +25,6 @@ public class NamedNetworkCodec<A> implements NetworkCodec<A> {
 
 	@Override
 	public String toString() {
-		return "%s(%s)".formatted(this.name, this.delegate);
+		return this.name;
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NetworkCodecBuilder.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NetworkCodecBuilder.java
@@ -1,0 +1,494 @@
+package org.quiltmc.qsl.networking.impl.codec;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import com.mojang.datafixers.util.Function10;
+import com.mojang.datafixers.util.Function11;
+import com.mojang.datafixers.util.Function12;
+import com.mojang.datafixers.util.Function13;
+import com.mojang.datafixers.util.Function14;
+import com.mojang.datafixers.util.Function15;
+import com.mojang.datafixers.util.Function16;
+import com.mojang.datafixers.util.Function3;
+import com.mojang.datafixers.util.Function4;
+import com.mojang.datafixers.util.Function5;
+import com.mojang.datafixers.util.Function6;
+import com.mojang.datafixers.util.Function7;
+import com.mojang.datafixers.util.Function8;
+import com.mojang.datafixers.util.Function9;
+
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+@SuppressWarnings("DuplicatedCode") // The duplicates are needed
+public final class NetworkCodecBuilder<R> {
+
+	public NetworkCodecBuilder() { }
+
+	public static <T> String codecName(List<Field<T, ?>> fields) {
+		return "Built[%s]".formatted(fields.stream()
+			.map(tField -> tField.codec.toString())
+			.reduce(new StringBuilder(), StringBuilder::append, StringBuilder::append)
+			.toString()
+	);
+}
+
+public NetworkCodec<R> createCodecBuilder(
+			List<Field<R, ?>> fields,
+			PacketByteBuf.Reader<R> initializer
+	) {
+		return new SimpleNetworkCodec<>(
+				(buf, a) -> fields.forEach(field -> field.encodeFrom(buf, a)),
+				initializer
+		).named(codecName(fields));
+	}
+
+	public <B, C> Function<BiFunction<B, C, R>, NetworkCodec<R>> create(
+			Field<R, B> field1,
+			Field<R, C> field2
+	) {
+		List<Field<R, ?>> fields = List.of(field1, field2);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf)
+		));
+	}
+
+	// create methods with 3 to 16 fields
+	public <B, C, D> Function<Function3<B, C, D, R>, NetworkCodec<R>> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3
+	) {
+		List<Field<R, ?>> fields = List.of(field1, field2, field3);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf)
+		));
+	}
+
+	public <B, C, D, E> Function<Function4<B, C, D, E, R>, NetworkCodec<R>> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3,
+			Field<R, E> field4
+	) {
+		List<Field<R, ?>> fields = List.of(field1, field2, field3, field4);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf),
+				field4.decode(buf)
+		));
+	}
+
+	public <B, C, D, E, F> Function<Function5<B, C, D, E, F, R>, NetworkCodec<R>> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3,
+			Field<R, E> field4,
+			Field<R, F> field5
+	) {
+		List<Field<R, ?>> fields = List.of(field1, field2, field3, field4, field5);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf),
+				field4.decode(buf),
+				field5.decode(buf)
+		));
+	}
+
+	public <B, C, D, E, F, G> Function<Function6<B, C, D, E, F, G, R>, NetworkCodec<R>> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3,
+			Field<R, E> field4,
+			Field<R, F> field5,
+			Field<R, G> field6
+	) {
+		List<Field<R, ?>> fields = List.of(field1, field2, field3, field4, field5, field6);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf),
+				field4.decode(buf),
+				field5.decode(buf),
+				field6.decode(buf)
+		));
+	}
+
+	public <B, C, D, E, F, G, H> Function<Function7<B, C, D, E, F, G, H, R>, NetworkCodec<R>> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3,
+			Field<R, E> field4,
+			Field<R, F> field5,
+			Field<R, G> field6,
+			Field<R, H> field7
+	) {
+		List<Field<R, ?>> fields = List.of(field1, field2, field3, field4, field5, field6, field7);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf),
+				field4.decode(buf),
+				field5.decode(buf),
+				field6.decode(buf),
+				field7.decode(buf)
+		));
+	}
+
+	public <B, C, D, E, F, G, H, I> Function<Function8<B, C, D, E, F, G, H, I, R>, NetworkCodec<R>> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3,
+			Field<R, E> field4,
+			Field<R, F> field5,
+			Field<R, G> field6,
+			Field<R, H> field7,
+			Field<R, I> field8
+	) {
+		List<Field<R, ?>> fields = List.of(field1, field2, field3, field4, field5, field6, field7, field8);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf),
+				field4.decode(buf),
+				field5.decode(buf),
+				field6.decode(buf),
+				field7.decode(buf),
+				field8.decode(buf)
+		));
+	}
+
+	public <B, C, D, E, F, G, H, I, J> Function<Function9<B, C, D, E, F, G, H, I, J, R>, NetworkCodec<R>> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3,
+			Field<R, E> field4,
+			Field<R, F> field5,
+			Field<R, G> field6,
+			Field<R, H> field7,
+			Field<R, I> field8,
+			Field<R, J> field9
+	) {
+		List<Field<R, ?>> fields = List.of(field1, field2, field3, field4, field5, field6, field7, field8, field9);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf),
+				field4.decode(buf),
+				field5.decode(buf),
+				field6.decode(buf),
+				field7.decode(buf),
+				field8.decode(buf),
+				field9.decode(buf)
+		));
+	}
+
+	public <B, C, D, E, F, G, H, I, J, K> Function<
+			Function10<B, C, D, E, F, G, H, I, J, K, R>,
+			NetworkCodec<R>
+		> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3,
+			Field<R, E> field4,
+			Field<R, F> field5,
+			Field<R, G> field6,
+			Field<R, H> field7,
+			Field<R, I> field8,
+			Field<R, J> field9,
+			Field<R, K> field10
+	) {
+		List<Field<R, ?>> fields = List.of(
+				field1, field2, field3, field4, field5, field6, field7, field8, field9, field10);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf),
+				field4.decode(buf),
+				field5.decode(buf),
+				field6.decode(buf),
+				field7.decode(buf),
+				field8.decode(buf),
+				field9.decode(buf),
+				field10.decode(buf)
+		));
+	}
+
+	public <B, C, D, E, F, G, H, I, J, K, L> Function<
+			Function11<B, C, D, E, F, G, H, I, J, K, L, R>,
+			NetworkCodec<R>
+		> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3,
+			Field<R, E> field4,
+			Field<R, F> field5,
+			Field<R, G> field6,
+			Field<R, H> field7,
+			Field<R, I> field8,
+			Field<R, J> field9,
+			Field<R, K> field10,
+			Field<R, L> field11
+	) {
+		List<Field<R, ?>> fields = List.of(
+				field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf),
+				field4.decode(buf),
+				field5.decode(buf),
+				field6.decode(buf),
+				field7.decode(buf),
+				field8.decode(buf),
+				field9.decode(buf),
+				field10.decode(buf),
+				field11.decode(buf)
+		));
+	}
+
+	public <B, C, D, E, F, G, H, I, J, K, L, M> Function<
+			Function12<B, C, D, E, F, G, H, I, J, K, L, M, R>,
+			NetworkCodec<R>
+		> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3,
+			Field<R, E> field4,
+			Field<R, F> field5,
+			Field<R, G> field6,
+			Field<R, H> field7,
+			Field<R, I> field8,
+			Field<R, J> field9,
+			Field<R, K> field10,
+			Field<R, L> field11,
+			Field<R, M> field12
+	) {
+		List<Field<R, ?>> fields = List.of(
+				field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf),
+				field4.decode(buf),
+				field5.decode(buf),
+				field6.decode(buf),
+				field7.decode(buf),
+				field8.decode(buf),
+				field9.decode(buf),
+				field10.decode(buf),
+				field11.decode(buf),
+				field12.decode(buf)
+		));
+	}
+
+	public <B, C, D, E, F, G, H, I, J, K, L, M, N> Function<
+			Function13<B, C, D, E, F, G, H, I, J, K, L, M, N, R>,
+			NetworkCodec<R>
+		> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3,
+			Field<R, E> field4,
+			Field<R, F> field5,
+			Field<R, G> field6,
+			Field<R, H> field7,
+			Field<R, I> field8,
+			Field<R, J> field9,
+			Field<R, K> field10,
+			Field<R, L> field11,
+			Field<R, M> field12,
+			Field<R, N> field13
+	) {
+		List<Field<R, ?>> fields = List.of(
+				field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12,
+				field13
+		);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf),
+				field4.decode(buf),
+				field5.decode(buf),
+				field6.decode(buf),
+				field7.decode(buf),
+				field8.decode(buf),
+				field9.decode(buf),
+				field10.decode(buf),
+				field11.decode(buf),
+				field12.decode(buf),
+				field13.decode(buf)
+		));
+	}
+
+	public <B, C, D, E, F, G, H, I, J, K, L, M, N, O> Function<
+			Function14<B, C, D, E, F, G, H, I, J, K, L, M, N, O, R>,
+			NetworkCodec<R>
+		> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3,
+			Field<R, E> field4,
+			Field<R, F> field5,
+			Field<R, G> field6,
+			Field<R, H> field7,
+			Field<R, I> field8,
+			Field<R, J> field9,
+			Field<R, K> field10,
+			Field<R, L> field11,
+			Field<R, M> field12,
+			Field<R, N> field13,
+			Field<R, O> field14
+	) {
+		List<Field<R, ?>> fields = List.of(
+				field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12,
+				field13, field14
+		);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf),
+				field4.decode(buf),
+				field5.decode(buf),
+				field6.decode(buf),
+				field7.decode(buf),
+				field8.decode(buf),
+				field9.decode(buf),
+				field10.decode(buf),
+				field11.decode(buf),
+				field12.decode(buf),
+				field13.decode(buf),
+				field14.decode(buf)
+		));
+	}
+
+	public <B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> Function<
+			Function15<B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, R>,
+			NetworkCodec<R>
+		> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3,
+			Field<R, E> field4,
+			Field<R, F> field5,
+			Field<R, G> field6,
+			Field<R, H> field7,
+			Field<R, I> field8,
+			Field<R, J> field9,
+			Field<R, K> field10,
+			Field<R, L> field11,
+			Field<R, M> field12,
+			Field<R, N> field13,
+			Field<R, O> field14,
+			Field<R, P> field15
+	) {
+		List<Field<R, ?>> fields = List.of(
+				field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12,
+				field13, field14, field15
+		);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf),
+				field4.decode(buf),
+				field5.decode(buf),
+				field6.decode(buf),
+				field7.decode(buf),
+				field8.decode(buf),
+				field9.decode(buf),
+				field10.decode(buf),
+				field11.decode(buf),
+				field12.decode(buf),
+				field13.decode(buf),
+				field14.decode(buf),
+				field15.decode(buf)
+		));
+	}
+
+	// make one for 16 fields
+	public <B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> Function<
+			Function16<B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>,
+			NetworkCodec<R>
+		> create(
+			Field<R, B> field1,
+			Field<R, C> field2,
+			Field<R, D> field3,
+			Field<R, E> field4,
+			Field<R, F> field5,
+			Field<R, G> field6,
+			Field<R, H> field7,
+			Field<R, I> field8,
+			Field<R, J> field9,
+			Field<R, K> field10,
+			Field<R, L> field11,
+			Field<R, M> field12,
+			Field<R, N> field13,
+			Field<R, O> field14,
+			Field<R, P> field15,
+			Field<R, Q> field16
+	) {
+		List<Field<R, ?>> fields = List.of(
+				field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12,
+				field13, field14, field15, field16
+		);
+
+		return ctor -> createCodecBuilder(fields, (buf) -> ctor.apply(
+				field1.decode(buf),
+				field2.decode(buf),
+				field3.decode(buf),
+				field4.decode(buf),
+				field5.decode(buf),
+				field6.decode(buf),
+				field7.decode(buf),
+				field8.decode(buf),
+				field9.decode(buf),
+				field10.decode(buf),
+				field11.decode(buf),
+				field12.decode(buf),
+				field13.decode(buf),
+				field14.decode(buf),
+				field15.decode(buf),
+				field16.decode(buf)
+		));
+	}
+
+	public static final class Field<OBJ, FT> {
+		private final NetworkCodec<FT> codec;
+		private final Function<? super OBJ, ? extends FT> mapper;
+
+		public Field(NetworkCodec<FT> codec, Function<? super OBJ, ? extends FT> mapper) {
+			this.codec = codec;
+			this.mapper = mapper;
+		}
+
+		public void encodeFrom(PacketByteBuf buf, OBJ OBJ) {
+			this.codec.encode(buf, mapper.apply(OBJ));
+		}
+
+		public FT decode(PacketByteBuf buf) {
+			return this.codec.decode(buf);
+		}
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NetworkCodecBuilder.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NetworkCodecBuilder.java
@@ -3,6 +3,7 @@ package org.quiltmc.qsl.networking.impl.codec;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.mojang.datafixers.util.Function10;
 import com.mojang.datafixers.util.Function11;
@@ -31,10 +32,9 @@ public final class NetworkCodecBuilder<R> {
 	public static <T> String codecName(List<Field<T, ?>> fields) {
 		return "Built[%s]".formatted(fields.stream()
 			.map(tField -> tField.codec.toString())
-			.reduce(new StringBuilder(), StringBuilder::append, StringBuilder::append)
-			.toString()
-	);
-}
+		    .collect(Collectors.joining(", "))
+		);
+	}
 
 	public NetworkCodec<R> createCodecBuilder(
 			List<Field<R, ?>> fields,

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NetworkCodecBuilder.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NetworkCodecBuilder.java
@@ -36,7 +36,7 @@ public final class NetworkCodecBuilder<R> {
 		);
 	}
 
-	public NetworkCodec<R> createCodecBuilder(
+	private NetworkCodec<R> createCodecBuilder(
 			List<Field<R, ?>> fields,
 			PacketByteBuf.Reader<R> initializer
 	) {

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NetworkCodecBuilder.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NetworkCodecBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.codec;
 
 import java.util.List;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NetworkCodecBuilder.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/NetworkCodecBuilder.java
@@ -36,7 +36,7 @@ public final class NetworkCodecBuilder<R> {
 	);
 }
 
-public NetworkCodec<R> createCodecBuilder(
+	public NetworkCodec<R> createCodecBuilder(
 			List<Field<R, ?>> fields,
 			PacketByteBuf.Reader<R> initializer
 	) {

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/OptionalNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/OptionalNetworkCodec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.codec;
 
 import java.util.Optional;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/OptionalNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/OptionalNetworkCodec.java
@@ -1,0 +1,31 @@
+package org.quiltmc.qsl.networking.impl.codec;
+
+import java.util.Optional;
+
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public class OptionalNetworkCodec<A> implements NetworkCodec<Optional<A>> {
+	private final NetworkCodec<A> entryCodec;
+
+	public OptionalNetworkCodec(NetworkCodec<A> entryCodec) {
+		this.entryCodec = entryCodec;
+	}
+
+	@Override
+	public Optional<A> decode(PacketByteBuf buf) {
+		return buf.readBoolean() ? Optional.of(this.entryCodec.decode(buf)) : Optional.empty();
+	}
+
+	@Override
+	public void encode(PacketByteBuf buf, Optional<A> data) {
+		buf.writeBoolean(data.isPresent());
+		data.ifPresent(a -> this.entryCodec.encode(buf, a));
+	}
+
+	@Override
+	public String toString() {
+		return "OptionalNetworkCodec[" + this.entryCodec + "]";
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/OptionalNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/OptionalNetworkCodec.java
@@ -6,7 +6,7 @@ import net.minecraft.network.PacketByteBuf;
 
 import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
 
-public class OptionalNetworkCodec<A> implements NetworkCodec<Optional<A>> {
+public final class OptionalNetworkCodec<A> implements NetworkCodec<Optional<A>> {
 	private final NetworkCodec<A> entryCodec;
 
 	public OptionalNetworkCodec(NetworkCodec<A> entryCodec) {

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PairNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PairNetworkCodec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.codec;
 
 import oshi.util.tuples.Pair;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PairNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PairNetworkCodec.java
@@ -1,0 +1,50 @@
+package org.quiltmc.qsl.networking.impl.codec;
+
+import oshi.util.tuples.Pair;
+
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public class PairNetworkCodec<A, B> implements NetworkCodec<Pair<A, B>> {
+	private final NetworkCodec<A> aCodec;
+	private final NetworkCodec<B> bCodec;
+
+	public PairNetworkCodec(NetworkCodec<A> aCodec, NetworkCodec<B> bCodec) {
+		this.aCodec = aCodec;
+		this.bCodec = bCodec;
+	}
+
+	@Override
+	public Pair<A, B> decode(PacketByteBuf buf) {
+		return new Pair<>(this.aCodec.decode(buf), this.bCodec.decode(buf));
+	}
+
+	public A decodeFirst(PacketByteBuf buf) {
+		return this.aCodec.decode(buf);
+	}
+
+	public B decodeSecond(PacketByteBuf buf) {
+		return this.bCodec.decode(buf);
+	}
+
+	@Override
+	public void encode(PacketByteBuf buf, Pair<A, B> data) {
+		this.aCodec.encode(buf, data.getA());
+		this.bCodec.encode(buf, data.getB());
+	}
+
+	public void encodeFirstAndSecond(PacketByteBuf buf, A a, B b) {
+		this.aCodec.encode(buf, a);
+		this.bCodec.encode(buf, b);
+	}
+
+	public MapNetworkCodec.EntryCodec<A, B> intoEntry() {
+		return this.aCodec.zip(this.bCodec);
+	}
+
+	@Override
+	public String toString() {
+		return "PairNetworkCodec{%s, %s}".formatted(this.aCodec, this.bCodec);
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PrimitiveNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PrimitiveNetworkCodec.java
@@ -25,7 +25,9 @@ public final class PrimitiveNetworkCodec {
 		public void encode(PacketByteBuf buf, Void data) { }
 	}
 
-	public static final class Boolean implements NetworkCodec<java.lang.Boolean> {
+	public enum Boolean implements NetworkCodec<java.lang.Boolean> {
+		INSTANCE;
+
 		@Override
 		public java.lang.Boolean decode(PacketByteBuf buf) {
 			return this.decodeBoolean(buf);
@@ -61,7 +63,9 @@ public final class PrimitiveNetworkCodec {
 		}
 	}
 
-	public static final class Byte implements NetworkCodec<java.lang.Byte> {
+	public enum Byte implements NetworkCodec<java.lang.Byte> {
+		INSTANCE;
+
 		@Override
 		public java.lang.Byte decode(PacketByteBuf buf) {
 			return this.decodeByte(buf);
@@ -101,7 +105,9 @@ public final class PrimitiveNetworkCodec {
 		}
 	}
 
-	public static final class Char implements NetworkCodec<Character> {
+	public enum Char implements NetworkCodec<Character> {
+		INSTANCE;
+
 		@Override
 		public Character decode(PacketByteBuf buf) {
 			return this.decodeChar(buf);
@@ -141,7 +147,9 @@ public final class PrimitiveNetworkCodec {
 		}
 	}
 
-	public static final class Short implements NetworkCodec<java.lang.Short> {
+	public enum Short implements NetworkCodec<java.lang.Short> {
+		INSTANCE;
+
 		@Override
 		public java.lang.Short decode(PacketByteBuf buf) {
 			return this.decodeShort(buf);
@@ -182,6 +190,10 @@ public final class PrimitiveNetworkCodec {
 	}
 
 	public static class Int implements NetworkCodec<Integer> {
+		public static final Int INSTANCE = new Int();
+
+		private Int() { }
+
 		@Override
 		public Integer decode(PacketByteBuf buf) {
 			return this.decodeInt(buf);
@@ -214,6 +226,9 @@ public final class PrimitiveNetworkCodec {
 	}
 
 	public static final class VarInt extends Int {
+		public static final VarInt INSTANCE = new VarInt();
+		private VarInt() { }
+
 		@Override
 		public int decodeInt(PacketByteBuf buf) {
 			return buf.readVarInt();
@@ -230,7 +245,9 @@ public final class PrimitiveNetworkCodec {
 		}
 	}
 
-	public static final class Float implements NetworkCodec<java.lang.Float> {
+	public enum Float implements NetworkCodec<java.lang.Float> {
+		INSTANCE;
+
 		@Override
 		public java.lang.Float decode(PacketByteBuf buf) {
 			return this.decodeFloat(buf);
@@ -271,6 +288,10 @@ public final class PrimitiveNetworkCodec {
 	}
 
 	public static class Long implements NetworkCodec<java.lang.Long> {
+		public static final Long INSTANCE = new Long();
+
+		private Long() { }
+
 		@Override
 		public java.lang.Long decode(PacketByteBuf buf) {
 			return this.decodeLong(buf);
@@ -303,6 +324,10 @@ public final class PrimitiveNetworkCodec {
 	}
 
 	public static final class VarLong extends Long {
+		public static final VarLong INSTANCE = new VarLong();
+
+		private VarLong() { }
+
 		@Override
 		public long decodeLong(PacketByteBuf buf) {
 			return buf.readVarLong();
@@ -319,7 +344,9 @@ public final class PrimitiveNetworkCodec {
 		}
 	}
 
-	public static final class Double implements NetworkCodec<java.lang.Double> {
+	public enum Double implements NetworkCodec<java.lang.Double> {
+		INSTANCE;
+
 		@Override
 		public java.lang.Double decode(PacketByteBuf buf) {
 			return this.decodeDouble(buf);

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PrimitiveNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PrimitiveNetworkCodec.java
@@ -1,0 +1,191 @@
+package org.quiltmc.qsl.networking.impl.codec;
+
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public final class PrimitiveNetworkCodec {
+	public static final class Boolean implements NetworkCodec<java.lang.Boolean> {
+		@Override
+		public java.lang.Boolean decode(PacketByteBuf buf) {
+			return this.decodeBoolean(buf);
+		}
+
+		@Override
+		public void encode(PacketByteBuf buf, java.lang.Boolean data) {
+			this.encodeBoolean(buf, data);
+		}
+
+		public boolean decodeBoolean(PacketByteBuf buf) {
+			return buf.readBoolean();
+		}
+
+		public void encodeBoolean(PacketByteBuf buf, boolean data) {
+			buf.writeBoolean(data);
+		}
+
+		@Override
+		public String toString() {
+			return "Boolean";
+		}
+	}
+
+	public static final class Byte implements NetworkCodec<java.lang.Byte> {
+		@Override
+		public java.lang.Byte decode(PacketByteBuf buf) {
+			return this.decodeByte(buf);
+		}
+
+		@Override
+		public void encode(PacketByteBuf buf, java.lang.Byte data) {
+			this.encodeByte(buf, data);
+		}
+
+		public byte decodeByte(PacketByteBuf buf) {
+			return buf.readByte();
+		}
+
+		public void encodeByte(PacketByteBuf buf, byte data) {
+			buf.writeByte(data);
+		}
+
+		@Override
+		public String toString() {
+			return "Byte";
+		}
+	}
+
+	public static final class Char implements NetworkCodec<Character> {
+		@Override
+		public Character decode(PacketByteBuf buf) {
+			return this.decodeChar(buf);
+		}
+
+		@Override
+		public void encode(PacketByteBuf buf, Character data) {
+			this.encodeChar(buf, data);
+		}
+
+		public char decodeChar(PacketByteBuf buf) {
+			return buf.readChar();
+		}
+
+		public void encodeChar(PacketByteBuf buf, char data) {
+			buf.writeChar(data);
+		}
+
+		@Override
+		public String toString() {
+			return "Char";
+		}
+	}
+
+	public static final class Short implements NetworkCodec<java.lang.Short> {
+		@Override
+		public java.lang.Short decode(PacketByteBuf buf) {
+			return this.decodeShort(buf);
+		}
+
+		@Override
+		public void encode(PacketByteBuf buf, java.lang.Short data) {
+			this.encodeShort(buf, data);
+		}
+
+		public short decodeShort(PacketByteBuf buf) {
+			return buf.readShort();
+		}
+
+		public void encodeShort(PacketByteBuf buf, short data) {
+			buf.writeShort(data);
+		}
+
+		@Override
+		public String toString() {
+			return "Short";
+		}
+	}
+
+	public static class Int implements NetworkCodec<Integer> {
+		@Override
+		public Integer decode(PacketByteBuf buf) {
+			return this.decodeInt(buf);
+		}
+
+		@Override
+		public void encode(PacketByteBuf buf, Integer data) {
+			this.encodeInt(buf, data);
+		}
+
+		public int decodeInt(PacketByteBuf buf) {
+			return buf.readInt();
+		}
+
+		public void encodeInt(PacketByteBuf buf, int data) {
+			buf.writeInt(data);
+		}
+
+		@Override
+		public String toString() {
+			return "Int";
+		}
+	}
+
+	public static final class VarInt extends Int {
+		@Override
+		public int decodeInt(PacketByteBuf buf) {
+			return buf.readVarInt();
+		}
+
+		@Override
+		public void encodeInt(PacketByteBuf buf, int data) {
+			buf.writeVarInt(data);
+		}
+
+		@Override
+		public String toString() {
+			return "VarInt";
+		}
+	}
+
+	public static class Long implements NetworkCodec<java.lang.Long> {
+		@Override
+		public java.lang.Long decode(PacketByteBuf buf) {
+			return this.decodeLong(buf);
+		}
+
+		@Override
+		public void encode(PacketByteBuf buf, java.lang.Long data) {
+			this.encodeLong(buf, data);
+		}
+
+		public long decodeLong(PacketByteBuf buf) {
+			return buf.readLong();
+		}
+
+		public void encodeLong(PacketByteBuf buf, long data) {
+			buf.writeLong(data);
+		}
+
+		@Override
+		public String toString() {
+			return "Long";
+		}
+	}
+
+	public static final class VarLong extends Long {
+		@Override
+		public long decodeLong(PacketByteBuf buf) {
+			return buf.readVarLong();
+		}
+
+		@Override
+		public void encodeLong(PacketByteBuf buf, long data) {
+			buf.writeVarLong(data);
+		}
+
+		@Override
+		public String toString() {
+			return "VarLong";
+		}
+	}
+}

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PrimitiveNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PrimitiveNetworkCodec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.codec;
 
 import java.util.function.DoubleFunction;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PrimitiveNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PrimitiveNetworkCodec.java
@@ -13,6 +13,18 @@ import net.minecraft.network.PacketByteBuf;
 import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
 
 public final class PrimitiveNetworkCodec {
+	public enum Null implements NetworkCodec<Void> {
+		INSTANCE;
+
+		@Override
+		public Void decode(PacketByteBuf buf) {
+			return null;
+		}
+
+		@Override
+		public void encode(PacketByteBuf buf, Void data) { }
+	}
+
 	public static final class Boolean implements NetworkCodec<java.lang.Boolean> {
 		@Override
 		public java.lang.Boolean decode(PacketByteBuf buf) {

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PrimitiveNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/PrimitiveNetworkCodec.java
@@ -1,5 +1,13 @@
 package org.quiltmc.qsl.networking.impl.codec;
 
+import java.util.function.DoubleFunction;
+import java.util.function.IntFunction;
+import java.util.function.LongFunction;
+import java.util.function.Predicate;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
+
 import net.minecraft.network.PacketByteBuf;
 
 import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
@@ -24,9 +32,20 @@ public final class PrimitiveNetworkCodec {
 			buf.writeBoolean(data);
 		}
 
+		public <A> NetworkCodec<A> mapBoolean(Predicate<A> to, FromBoolean<A> from) {
+			return new SimpleNetworkCodec<>(
+					(byteBuf, a) -> this.encodeBoolean(byteBuf, to.test(a)),
+					byteBuf -> from.fromBoolean(this.decodeBoolean(byteBuf))
+			);
+		}
+
 		@Override
 		public String toString() {
 			return "Boolean";
+		}
+
+		public interface FromBoolean<A> {
+			A fromBoolean(boolean b);
 		}
 	}
 
@@ -49,9 +68,24 @@ public final class PrimitiveNetworkCodec {
 			buf.writeByte(data);
 		}
 
+		public <A> NetworkCodec<A> mapByte(ToByte<A> to, FromByte<A> from) {
+			return new SimpleNetworkCodec<>(
+					(byteBuf, a) -> this.encodeByte(byteBuf, to.toByte(a)),
+					byteBuf -> from.fromByte(this.decodeByte(byteBuf))
+			);
+		}
+
 		@Override
 		public String toString() {
 			return "Byte";
+		}
+
+		public interface ToByte<A> {
+			byte toByte(A a);
+		}
+
+		public interface FromByte<A> {
+			A fromByte(byte b);
 		}
 	}
 
@@ -74,9 +108,24 @@ public final class PrimitiveNetworkCodec {
 			buf.writeChar(data);
 		}
 
+		public <A> NetworkCodec<A> mapChar(ToChar<A> to, FromChar<A> from) {
+			return new SimpleNetworkCodec<>(
+					(byteBuf, a) -> this.encodeChar(byteBuf, to.toChar(a)),
+					byteBuf -> from.fromChar(this.decodeChar(byteBuf))
+			);
+		}
+
 		@Override
 		public String toString() {
 			return "Char";
+		}
+
+		public interface ToChar<A> {
+			char toChar(A a);
+		}
+
+		public interface FromChar<A> {
+			A fromChar(char c);
 		}
 	}
 
@@ -99,9 +148,24 @@ public final class PrimitiveNetworkCodec {
 			buf.writeShort(data);
 		}
 
+		public <A> NetworkCodec<A> mapShort(ToShort<A> to, FromShort<A> from) {
+			return new SimpleNetworkCodec<>(
+					(byteBuf, a) -> this.encodeShort(byteBuf, to.toShort(a)),
+					byteBuf -> from.fromShort(this.decodeShort(byteBuf))
+			);
+		}
+
 		@Override
 		public String toString() {
 			return "Short";
+		}
+
+		public interface ToShort<A> {
+			short toShort(A a);
+		}
+
+		public interface FromShort<A> {
+			A fromShort(short s);
 		}
 	}
 
@@ -122,6 +186,13 @@ public final class PrimitiveNetworkCodec {
 
 		public void encodeInt(PacketByteBuf buf, int data) {
 			buf.writeInt(data);
+		}
+
+		public <A> NetworkCodec<A> mapInt(ToIntFunction<A> to, IntFunction<A> from) {
+			return new SimpleNetworkCodec<>(
+					(byteBuf, a) -> this.encodeInt(byteBuf, to.applyAsInt(a)),
+					byteBuf -> from.apply(this.decodeInt(byteBuf))
+			);
 		}
 
 		@Override
@@ -147,6 +218,46 @@ public final class PrimitiveNetworkCodec {
 		}
 	}
 
+	public static final class Float implements NetworkCodec<java.lang.Float> {
+		@Override
+		public java.lang.Float decode(PacketByteBuf buf) {
+			return this.decodeFloat(buf);
+		}
+
+		@Override
+		public void encode(PacketByteBuf buf, java.lang.Float data) {
+			this.encodeFloat(buf, data);
+		}
+
+		public float decodeFloat(PacketByteBuf buf) {
+			return buf.readFloat();
+		}
+
+		public void encodeFloat(PacketByteBuf buf, float data) {
+			buf.writeFloat(data);
+		}
+
+		public <A> NetworkCodec<A> mapFloat(ToFloatFunction<A> to, FromFloatFunction<A> from) {
+			return new SimpleNetworkCodec<>(
+					(byteBuf, a) -> this.encodeFloat(byteBuf, to.toFloat(a)),
+					byteBuf -> from.fromFloat(this.decodeFloat(byteBuf))
+			);
+		}
+
+		@Override
+		public String toString() {
+			return "Float";
+		}
+
+		public interface ToFloatFunction<A> {
+			float toFloat(A a);
+		}
+
+		public interface FromFloatFunction<A> {
+			A fromFloat(float f);
+		}
+	}
+
 	public static class Long implements NetworkCodec<java.lang.Long> {
 		@Override
 		public java.lang.Long decode(PacketByteBuf buf) {
@@ -164,6 +275,13 @@ public final class PrimitiveNetworkCodec {
 
 		public void encodeLong(PacketByteBuf buf, long data) {
 			buf.writeLong(data);
+		}
+
+		public <A> NetworkCodec<A> mapLong(ToLongFunction<A> to, LongFunction<A> from) {
+			return new SimpleNetworkCodec<>(
+					(byteBuf, a) -> this.encodeLong(byteBuf, to.applyAsLong(a)),
+					byteBuf -> from.apply(this.decodeLong(byteBuf))
+			);
 		}
 
 		@Override
@@ -186,6 +304,38 @@ public final class PrimitiveNetworkCodec {
 		@Override
 		public String toString() {
 			return "VarLong";
+		}
+	}
+
+	public static final class Double implements NetworkCodec<java.lang.Double> {
+		@Override
+		public java.lang.Double decode(PacketByteBuf buf) {
+			return this.decodeDouble(buf);
+		}
+
+		@Override
+		public void encode(PacketByteBuf buf, java.lang.Double data) {
+			this.encodeDouble(buf, data);
+		}
+
+		public double decodeDouble(PacketByteBuf buf) {
+			return buf.readDouble();
+		}
+
+		public void encodeDouble(PacketByteBuf buf, double data) {
+			buf.writeDouble(data);
+		}
+
+		public <A> NetworkCodec<A> mapDouble(ToDoubleFunction<A> to, DoubleFunction<A> from) {
+			return new SimpleNetworkCodec<>(
+					(byteBuf, a) -> this.encodeDouble(byteBuf, to.applyAsDouble(a)),
+					byteBuf -> from.apply(this.decodeDouble(byteBuf))
+			).named("Double [mapped]");
+		}
+
+		@Override
+		public String toString() {
+			return "Double";
 		}
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/SimpleNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/SimpleNetworkCodec.java
@@ -1,7 +1,5 @@
 package org.quiltmc.qsl.networking.impl.codec;
 
-import org.jetbrains.annotations.Nullable;
-
 import net.minecraft.network.PacketByteBuf;
 
 import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
@@ -9,13 +7,10 @@ import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
 public class SimpleNetworkCodec<A> implements NetworkCodec<A> {
 	private final PacketByteBuf.Reader<A> reader;
 	private final PacketByteBuf.Writer<A> writer;
-	@Nullable
-	private final String name;
 
-	public SimpleNetworkCodec(PacketByteBuf.Writer<A> writer, PacketByteBuf.Reader<A> reader, @Nullable String name) {
+	public SimpleNetworkCodec(PacketByteBuf.Writer<A> writer, PacketByteBuf.Reader<A> reader) {
 		this.reader = reader;
 		this.writer = writer;
-		this.name = name;
 	}
 
 	@Override
@@ -40,6 +35,6 @@ public class SimpleNetworkCodec<A> implements NetworkCodec<A> {
 
 	@Override
 	public String toString() {
-		return this.name != null ? "SimpleNetworkCodec[" + this.name + "]" : "SimpleNetworkCodec";
+		return "SimpleNetworkCodec";
 	}
 }

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/SimpleNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/SimpleNetworkCodec.java
@@ -12,7 +12,7 @@ public class SimpleNetworkCodec<A> implements NetworkCodec<A> {
 	@Nullable
 	private final String name;
 
-	public SimpleNetworkCodec(PacketByteBuf.Reader<A> reader, PacketByteBuf.Writer<A> writer, @Nullable String name) {
+	public SimpleNetworkCodec(PacketByteBuf.Writer<A> writer, PacketByteBuf.Reader<A> reader, @Nullable String name) {
 		this.reader = reader;
 		this.writer = writer;
 		this.name = name;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/SimpleNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/SimpleNetworkCodec.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.impl.codec;
 
 import net.minecraft.network.PacketByteBuf;

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/SimpleNetworkCodec.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/codec/SimpleNetworkCodec.java
@@ -1,0 +1,45 @@
+package org.quiltmc.qsl.networking.impl.codec;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.network.PacketByteBuf;
+
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public class SimpleNetworkCodec<A> implements NetworkCodec<A> {
+	private final PacketByteBuf.Reader<A> reader;
+	private final PacketByteBuf.Writer<A> writer;
+	@Nullable
+	private final String name;
+
+	public SimpleNetworkCodec(PacketByteBuf.Reader<A> reader, PacketByteBuf.Writer<A> writer, @Nullable String name) {
+		this.reader = reader;
+		this.writer = writer;
+		this.name = name;
+	}
+
+	@Override
+	public A decode(PacketByteBuf buf) {
+		return this.reader.apply(buf);
+	}
+
+	@Override
+	public void encode(PacketByteBuf buf, A data) {
+		this.writer.accept(buf, data);
+	}
+
+	@Override
+	public PacketByteBuf.Reader<A> asReader() {
+		return this.reader;
+	}
+
+	@Override
+	public PacketByteBuf.Writer<A> asWriter() {
+		return this.writer;
+	}
+
+	@Override
+	public String toString() {
+		return this.name != null ? "SimpleNetworkCodec[" + this.name + "]" : "SimpleNetworkCodec";
+	}
+}

--- a/library/core/networking/src/testmod/java/org/quiltmc/qsl/networking/test/codec/CodecTest.java
+++ b/library/core/networking/src/testmod/java/org/quiltmc/qsl/networking/test/codec/CodecTest.java
@@ -1,0 +1,61 @@
+package org.quiltmc.qsl.networking.test.codec;
+
+import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.BOOLEAN;
+import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.BYTE;
+import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.NBT;
+import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.constant;
+import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.indexOf;
+
+import java.util.Optional;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.registry.Registry;
+
+import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.qsl.base.api.entrypoint.ModInitializer;
+import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
+
+public class CodecTest implements ModInitializer {
+	public static final NetworkCodec<ItemStack> NON_EMPTY_ITEM_STACK = NetworkCodec.<ItemStack>builder().create(
+			indexOf(Registry.ITEM).fieldOf(ItemStack::getItem),
+			BYTE.fieldOf(stack -> (byte) stack.getCount()),
+			NBT.optional().fieldOf(stack -> Optional.ofNullable(stack.getNbt()))
+	).apply((item, count, nbt) -> {
+		var stack = new ItemStack(item, count);
+		nbt.ifPresent(stack::setNbt);
+		return stack;
+	}).named("NonEmptyItemStack");
+
+	public static final NetworkCodec<ItemStack> ITEM_STACK = BOOLEAN.dispatch(
+			stack -> !stack.isEmpty(),
+			hasItem -> hasItem ? NON_EMPTY_ITEM_STACK : constant(ItemStack.EMPTY)
+	).named("ItemStack");
+
+	@Override
+	public void onInitialize(ModContainer mod) {
+		System.out.println(ITEM_STACK);
+		PacketByteBuf buf = ITEM_STACK.createBuffer(ItemStack.EMPTY);
+
+		System.out.println(buf.readableBytes());
+
+		if (!ITEM_STACK.decode(buf).isEmpty()) {
+			throw new IllegalStateException("Decode failed");
+		}
+
+		ItemStack acaciaStack = new ItemStack(Items.ACACIA_FENCE, 12);
+		NbtCompound sub = new NbtCompound();
+		sub.putString("Hello", "World");
+		sub.putInt("Int", 42);
+		sub.putDouble("Float", 3.14159265d);
+		acaciaStack.getOrCreateNbt().put("SubTag", sub);
+
+		var buf2 = ITEM_STACK.createBuffer(acaciaStack);
+		System.out.println(buf2.readableBytes());
+
+		var res = ITEM_STACK.decode(buf2);
+		System.out.println(res + res.getNbt().toString());
+	}
+}

--- a/library/core/networking/src/testmod/java/org/quiltmc/qsl/networking/test/codec/CodecTest.java
+++ b/library/core/networking/src/testmod/java/org/quiltmc/qsl/networking/test/codec/CodecTest.java
@@ -1,23 +1,36 @@
 package org.quiltmc.qsl.networking.test.codec;
 
+import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.BLOCK_POS;
 import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.BOOLEAN;
 import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.BYTE;
 import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.NBT;
 import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.constant;
 import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.indexOf;
 
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.registry.Registry;
 
 import org.quiltmc.loader.api.ModContainer;
 import org.quiltmc.qsl.base.api.entrypoint.ModInitializer;
+import org.quiltmc.qsl.networking.api.PacketSender;
+import org.quiltmc.qsl.networking.api.channel.C2SNetworkChannel;
+import org.quiltmc.qsl.networking.api.channel.NetworkChannel;
+import org.quiltmc.qsl.networking.api.channel.S2CNetworkChannel;
+import org.quiltmc.qsl.networking.api.channel.TwoWayNetworkChannel;
 import org.quiltmc.qsl.networking.api.codec.NetworkCodec;
 
 public class CodecTest implements ModInitializer {
-	public static final NetworkCodec<ItemStack> NON_EMPTY_ITEM_STACK = NetworkCodec.<ItemStack>builder().create(
+	public static final NetworkCodec<ItemStack> NON_EMPTY_ITEM_STACK = NetworkCodec.<ItemStack>build().create(
 			indexOf(Registry.ITEM).fieldOf(ItemStack::getItem),
 			BYTE.fieldOf(stack -> (byte) stack.getCount()),
 			NBT.fieldOf(ItemStack::getNbt)
@@ -35,6 +48,34 @@ public class CodecTest implements ModInitializer {
 			stack -> !stack.isEmpty(),
 			hasItem -> hasItem ? NON_EMPTY_ITEM_STACK : constant(ItemStack.EMPTY)
 	).named("ItemStack");
+
+	public static final C2SNetworkChannel<BlockPos> CHANNEL = NetworkChannel.createC2S(
+			new Identifier("quiltmc", "test"),
+			BLOCK_POS,
+			() -> blockPos -> (server, sender, handler, responseSender) -> System.out.println("Hello channel world!")
+	);
+
+	public record Ctx(BlockPos pos, ItemStack stack) implements S2CNetworkChannel.Handler {
+		public static final NetworkCodec<Ctx> CODEC = NetworkCodec.<Ctx>build().create(
+				BLOCK_POS.fieldOf(Ctx::pos),
+				ITEM_STACK.fieldOf(Ctx::stack)
+		).apply(Ctx::new).named("Ctx");
+
+		@Environment(EnvType.CLIENT)
+		@Override
+		public void clientHandle(MinecraftClient client, ClientPlayNetworkHandler handler, PacketSender responseSender) {
+			System.out.println("Hello client world!");
+		}
+	}
+	public static final S2CNetworkChannel<Ctx> CHANNEL_2 =
+			NetworkChannel.createS2C(new Identifier("quiltmc", "test"), Ctx.CODEC);
+
+	public static final TwoWayNetworkChannel<ItemStack> STACK_CHANNEL = NetworkChannel.createTwoWay(
+			new Identifier("quiltmc", "test"),
+			ITEM_STACK,
+			() -> stack -> (server, sender, handler, responseSender) -> System.out.println("Hello stack channel world!"),
+			() -> stack -> (client, handler, responseSender) -> System.out.println("Hello stack channel world!")
+	);
 
 	@Override
 	public void onInitialize(ModContainer mod) {

--- a/library/core/networking/src/testmod/java/org/quiltmc/qsl/networking/test/codec/CodecTest.java
+++ b/library/core/networking/src/testmod/java/org/quiltmc/qsl/networking/test/codec/CodecTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.qsl.networking.test.codec;
 
 import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.BLOCK_POS;

--- a/library/core/networking/src/testmod/java/org/quiltmc/qsl/networking/test/codec/CodecTest.java
+++ b/library/core/networking/src/testmod/java/org/quiltmc/qsl/networking/test/codec/CodecTest.java
@@ -6,8 +6,6 @@ import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.NBT;
 import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.constant;
 import static org.quiltmc.qsl.networking.api.codec.NetworkCodec.indexOf;
 
-import java.util.Optional;
-
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
@@ -22,10 +20,14 @@ public class CodecTest implements ModInitializer {
 	public static final NetworkCodec<ItemStack> NON_EMPTY_ITEM_STACK = NetworkCodec.<ItemStack>builder().create(
 			indexOf(Registry.ITEM).fieldOf(ItemStack::getItem),
 			BYTE.fieldOf(stack -> (byte) stack.getCount()),
-			NBT.optional().fieldOf(stack -> Optional.ofNullable(stack.getNbt()))
+			NBT.fieldOf(ItemStack::getNbt)
 	).apply((item, count, nbt) -> {
 		var stack = new ItemStack(item, count);
-		nbt.ifPresent(stack::setNbt);
+
+		if (nbt != null) {
+			stack.setNbt(nbt);
+		}
+
 		return stack;
 	}).named("NonEmptyItemStack");
 
@@ -52,7 +54,7 @@ public class CodecTest implements ModInitializer {
 		sub.putDouble("Float", 3.14159265d);
 		acaciaStack.getOrCreateNbt().put("SubTag", sub);
 
-		var buf2 = ITEM_STACK.createBuffer(acaciaStack);
+		var buf2 = NetworkCodec.ITEM_STACK.createBuffer(acaciaStack);
 		System.out.println(buf2.readableBytes());
 
 		var res = ITEM_STACK.decode(buf2);

--- a/library/core/networking/src/testmod/resources/quilt.mod.json
+++ b/library/core/networking/src/testmod/resources/quilt.mod.json
@@ -14,7 +14,8 @@
       "init": [
         "org.quiltmc.qsl.networking.test.keybindreciever.NetworkingKeyBindPacketTest",
         "org.quiltmc.qsl.networking.test.login.NetworkingLoginQueryTest",
-        "org.quiltmc.qsl.networking.test.play.NetworkingPlayPacketTest"
+        "org.quiltmc.qsl.networking.test.play.NetworkingPlayPacketTest",
+        "org.quiltmc.qsl.networking.test.codec.CodecTest"
       ],
       "events": [
         "org.quiltmc.qsl.networking.test.channeltest.NetworkingChannelTest"


### PR DESCRIPTION
This PR adds:
* NetworkChannels to the networking API. They started as a test for NetworkCodecs but ended up making me like them enough to make them public API. They are a wrapper around Server/ClientPlayerNetworking that makes it so the user never has to interact with a PacketByteBuf. They contain a NetworkCodec and they use that as well as a supplied handler in order to handle messages. The user just needs to create the channel and specify a way to handle it.

More tests coming soon(TM).
This depends on #180 since it uses NetworkCodecs.