### PR TITLE
Use QuiltLoader.createModTable instead of manually generating the mod list

### DIFF
--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/impl/CrashInfoImpl.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/impl/CrashInfoImpl.java
@@ -29,6 +29,6 @@ import org.quiltmc.qsl.crash.api.CrashReportEvents;
 public final class CrashInfoImpl implements CrashReportEvents.SystemDetails {
 	@Override
 	public void addDetails(SystemDetails details) {
-		details.addSection("Quilt Mods", () -> "\n" + QuiltLoader.createModTable());
+		details.addSection("Quilt Mods", () -> "\n\t\t" + QuiltLoader.createModTable().replace("\n", "\n\t\t"));
 	}
 }

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/impl/CrashInfoImpl.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/impl/CrashInfoImpl.java
@@ -29,6 +29,6 @@ import org.quiltmc.qsl.crash.api.CrashReportEvents;
 public final class CrashInfoImpl implements CrashReportEvents.SystemDetails {
 	@Override
 	public void addDetails(SystemDetails details) {
-		details.addSection("Quilt Mods", QuiltLoader::createModTable);
+		details.addSection("Quilt Mods", () -> "\n" + QuiltLoader.createModTable());
 	}
 }

--- a/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/impl/CrashInfoImpl.java
+++ b/library/core/crash_info/src/main/java/org/quiltmc/qsl/crash/impl/CrashInfoImpl.java
@@ -29,20 +29,6 @@ import org.quiltmc.qsl.crash.api.CrashReportEvents;
 public final class CrashInfoImpl implements CrashReportEvents.SystemDetails {
 	@Override
 	public void addDetails(SystemDetails details) {
-		details.addSection("Quilt Mods", () -> {
-			var builder = new StringBuilder();
-
-			QuiltLoader.getAllMods().stream().sorted(Comparator.comparing(o -> o.metadata().id())).forEach(mod -> {
-				var metadata = mod.metadata();
-
-				builder.append("\n\t\t%s: %s %s".formatted(
-						metadata.id(),
-						metadata.name(),
-						metadata.version().raw())
-				);
-			});
-
-			return builder.toString();
-		});
+		details.addSection("Quilt Mods", QuiltLoader::createModTable);
 	}
 }


### PR DESCRIPTION
This means QSL will automatically gain information about newer loader features (like what plugin loaded a given mod) when loader-plugins is released, and will add source paths too (also when loader plugins are released).

An example output (taken from *loader*, since I am having trouble building QSL locally :/ )
```
| Index | Mod                      | ID                                                        | Version  |
|------:|--------------------------|-----------------------------------------------------------|----------|
|    19 | GroovyDuvet: Core        | groovyduvet_core                                          | 1.0.2    |
|    17 | Minecraft                | minecraft                                                 | 1.19.2   |
|    18 | OpenJDK 64-Bit Server VM | java                                                      | 18       |
|    20 | Quilt Loader             | quilt_loader                                              | 0.17.4   |
|     9 | groovy                   | org_apache_groovy_groovy                                  | 4.0.4    |
|     8 | jackson-databind         | com_fasterxml_jackson_core_jackson-databind               | 2.13.3   |
|    12 | jackson-dataformat-toml  | com_fasterxml_jackson_dataformat_jackson-dataformat-toml  | 2.13.3   |
|     5 | mapping-io               | net_fabricmc_mapping-io                                   | 0.3.0    |
|------:|--------------------------|-----------------------------------------------------------|----------|
```
Since loader-plugins is in development the mod table will look something like this when it's merged (and the user is using it - with no other code changes to QSL required):
```
| Mod                                   | ID                                     | Version               | Plugin                 | File(s)                                                                                                                                                                         | Sub-Files                                                          | Sub-Files                                                       | Sub-Files                                       | Sub-Files                                     | Sub-Files                                     |
|---------------------------------------|----------------------------------------|-----------------------|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|-----------------------------------------------------------------|-------------------------------------------------|-----------------------------------------------|-----------------------------------------------|
| Cardinal Components API (base)        | cardinal-components-base               | 5.0.1                 | quilted_fabric_loader  | <mods>/twilightforest-fabric-1.19.2-4.2.299.jar                                                                                                                                 | /META-INF/jars/cardinal-components-base-5.0.1.jar                  |                                                                 |                                                 |                                               |                                               |
| Cardinal Components API (entities)    | cardinal-components-entity             | 5.0.1                 | quilted_fabric_loader  | <mods>/twilightforest-fabric-1.19.2-4.2.299.jar                                                                                                                                 | /META-INF/jars/cardinal-components-entity-5.0.1.jar                |                                                                 |                                                 |                                               |                                               |
| Minecraft                             | minecraft                              | 1.18.2                | quilt_loader           | /home/alexiil/.gradle/caches/quilt-loom/1.18.2/loom.mappings.1_18_2.layered+hash.917620836-v2/minecraft-merged-named.jar                                                        |                                                                    |                                                                 |                                                 |                                               |                                               |
| MixinExtras                           | com_github_llamalad7_mixinextras       | 0.0.10                | quilted_fabric_loader  | <mods>/twilightforest-fabric-1.19.2-4.2.299.jar                                                                                                                                 | /META-INF/jars/serialization-hooks-0.3.22.jar                      | /META-INF/jars/MixinExtras-0.0.10.jar                           |                                                 |                                               |                                               |
| OpenJDK 64-Bit Server VM              | java                                   | 17                    | quilt_loader           | /usr/lib/jvm/java-17-openjdk-amd64                                                                                                                                              |                                                                    |                                                                 |                                                 |                                               |                                               |
| Porting Lib Accessors                 | porting_lib_accessors                  | 2.0.547+1.19.2        | quilted_fabric_loader  | <mods>/twilightforest-fabric-1.19.2-4.2.299.jar                                                                                                                                 | /META-INF/jars/porting-lib-2.0.547+1.19.2.jar                      | /META-INF/jars/obj_loader-2.0.547+1.19.2.jar                    | /META-INF/jars/model_loader-2.0.547+1.19.2.jar  | /META-INF/jars/extensions-2.0.547+1.19.2.jar  | /META-INF/jars/accessors-2.0.547+1.19.2.jar   |
| Porting Lib Attributes                | porting_lib_attributes                 | 2.0.547+1.19.2        | quilted_fabric_loader  | <mods>/twilightforest-fabric-1.19.2-4.2.299.jar                                                                                                                                 | /META-INF/jars/porting-lib-2.0.547+1.19.2.jar                      | /META-INF/jars/obj_loader-2.0.547+1.19.2.jar                    | /META-INF/jars/model_loader-2.0.547+1.19.2.jar  | /META-INF/jars/extensions-2.0.547+1.19.2.jar  | /META-INF/jars/attributes-2.0.547+1.19.2.jar  |
| Porting Lib Base                      | porting_lib_base                       | 2.0.547+1.19.2        | quilted_fabric_loader  | <mods>/twilightforest-fabric-1.19.2-4.2.299.jar                                                                                                                                 | /META-INF/jars/porting-lib-2.0.547+1.19.2.jar                      | /META-INF/jars/base-2.0.547+1.19.2.jar                          |                                                 |                                               |                                               |
| Porting Lib Common                    | porting_lib_common                     | 2.0.547+1.19.2        | quilted_fabric_loader  | <mods>/twilightforest-fabric-1.19.2-4.2.299.jar                                                                                                                                 | /META-INF/jars/porting-lib-2.0.547+1.19.2.jar                      | /META-INF/jars/transfer-2.0.547+1.19.2.jar                      | /META-INF/jars/common-2.0.547+1.19.2.jar        |                                               |                                               |
| Porting Lib Constants                 | porting_lib_constants                  | 2.0.547+1.19.2        | quilted_fabric_loader  | <mods>/twilightforest-fabric-1.19.2-4.2.299.jar                                                                                                                                 | /META-INF/jars/porting-lib-2.0.547+1.19.2.jar                      | /META-INF/jars/transfer-2.0.547+1.19.2.jar                      | /META-INF/jars/constants-2.0.547+1.19.2.jar     |                                               |                                               |
| Porting Lib Entity                    | porting_lib_entity                     | 2.0.547+1.19.2        | quilted_fabric_loader  | <mods>/twilightforest-fabric-1.19.2-4.2.299.jar                                                                                                                                 | /META-INF/jars/porting-lib-2.0.547+1.19.2.jar                      | /META-INF/jars/entity-2.0.547+1.19.2.jar                        |                                                 |                                               |                                               |
| Porting Lib Extensions                | porting_lib_extensions                 | 2.0.547+1.19.2        | quilted_fabric_loader  | <mods>/twilightforest-fabric-1.19.2-4.2.299.jar                                                                                                                                 | /META-INF/jars/porting-lib-2.0.547+1.19.2.jar                      | /META-INF/jars/obj_loader-2.0.547+1.19.2.jar                    | /META-INF/jars/model_loader-2.0.547+1.19.2.jar  | /META-INF/jars/extensions-2.0.547+1.19.2.jar  |                                               |
| jsr305                                | com_google_code_findbugs_jsr305        | 3.0.2                 | quilted_fabric_loader  | <mods>/twilightforest-fabric-1.19.2-4.2.299.jar                                                                                                                                 | /META-INF/jars/jsr305-3.0.2.jar                                    |                                                                 |                                                 |                                               |                                               |
| minecraft_test                        | minecraft_test                         | 1.0.0                 | quilt_loader           | /home/alexiil/Documents/dev/minecraft/1.12/Quilt-Toolchain/quilt-loader-mod-resolution/minecraft/minecraft-test/bin/main                                                        |                                                                    |                                                                 |                                                 |                                               |                                               |
| toml                                  | com_electronwill_night-config_toml     | 3.6.3                 | quilted_fabric_loader  | <mods>/twilightforest-fabric-1.19.2-4.2.299.jar                                                                                                                                 | /META-INF/jars/toml-3.6.3.jar                                      |                                                                 |                                                 |                                               |                                               |
|---------------------------------------|----------------------------------------|-----------------------|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|-----------------------------------------------------------------|-------------------------------------------------|-----------------------------------------------|-----------------------------------------------|
```
(Both tables have been shrunk down for clarity - the `Index` column is missing since this was taken from a dev build).