### PR TITLE
Better dynamic registries setup event

### DIFF
--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/DynamicRegistryManagerSetupContext.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/DynamicRegistryManagerSetupContext.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.registry.api.event;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.DynamicRegistryManager;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryKey;
+
+/**
+ * Represents the {@link DynamicRegistryManager} setup context provided in the {@link RegistryEvents#DYNAMIC_REGISTRY_SETUP} event.
+ */
+@ApiStatus.NonExtendable
+public interface DynamicRegistryManagerSetupContext {
+	/**
+	 * {@return the dynamic registry manager that is being currently setup}
+	 */
+	@Contract(pure = true)
+	@NotNull DynamicRegistryManager registryManager();
+
+	/**
+	 * {@return the resource manager that is used to setup the dynamic registries}
+	 */
+	@Contract(pure = true)
+	@NotNull ResourceManager resourceManager();
+
+	/**
+	 * Attempts to safely register a game object into the given registry.
+	 *
+	 * @param registryKey        the key of the registry to register into
+	 * @param id                 the identifier of the game object to register
+	 * @param gameObjectSupplier the supplier of the game object to register
+	 * @param <V>                the type of game object to register
+	 * @return the optional game object, if the registry is present then the optional is filled, or empty otherwise
+	 */
+	default <V> @NotNull Optional<V> register(@NotNull RegistryKey<? extends Registry<V>> registryKey, @NotNull Identifier id,
+			@NotNull Supplier<V> gameObjectSupplier) {
+		return this.registryManager().getOptional(registryKey)
+				.map(registry -> Registry.register(registry, id, gameObjectSupplier.get()));
+	}
+
+	/**
+	 * Gets the registries requested by their keys.
+	 * <p>
+	 * If one of the queried registries isn't found, then this method will return {@code null}.
+	 *
+	 * @param registryKeys the keys of the registries to get
+	 * @return the registry map if all the queried registries have been found, or {@code null} otherwise
+	 */
+	@Contract(pure = true)
+	default @Nullable RegistryMap getRegistries(@NotNull Set<RegistryKey<? extends Registry<?>>> registryKeys) {
+		if (registryKeys.size() == 0) throw new IllegalArgumentException("Please provide at least one registry to gather.");
+
+		Map<RegistryKey<? extends Registry<?>>, Registry<?>> foundRegistries = null;
+
+		for (var key : registryKeys) {
+			var maybe = this.registryManager().getOptional(key);
+
+			if (maybe.isPresent()) {
+				if (foundRegistries == null) {
+					foundRegistries = new Reference2ObjectOpenHashMap<>();
+				}
+
+				foundRegistries.put(key, maybe.get());
+			}
+		}
+
+		if (foundRegistries == null || foundRegistries.size() != registryKeys.size()) {
+			return null;
+		}
+
+		return new RegistryMap(foundRegistries);
+	}
+
+	/**
+	 * Executes the given action if all the provided registry keys are present in the {@link DynamicRegistryManager}.
+	 *
+	 * @param action       the action
+	 * @param registryKeys the registry keys to check
+	 */
+	default void withRegistries(@NotNull Consumer<RegistryMap> action, @NotNull Set<RegistryKey<? extends Registry<?>>> registryKeys) {
+		var registries = this.getRegistries(registryKeys);
+
+		if (registries != null) {
+			action.accept(registries);
+		}
+	}
+
+	/**
+	 * Attempts to create a new registry monitor for the given registry.
+	 *
+	 * @param registryKey the key of the registry to monitor
+	 * @param action      the monitor callback
+	 * @param <V>         the type of values held in the registry
+	 */
+	default <V> void monitor(RegistryKey<? extends Registry<V>> registryKey, Consumer<RegistryMonitor<V>> action) {
+		this.registryManager().getOptional(registryKey).ifPresent(registry -> {
+			action.accept(RegistryMonitor.create(registry));
+		});
+	}
+
+	/**
+	 * Represents a map of known registries.
+	 *
+	 * @param registries the map of registries
+	 */
+	record RegistryMap(Map<RegistryKey<? extends Registry<?>>, Registry<?>> registries) {
+		/**
+		 * Gets the registry from its key in this map.
+		 *
+		 * @param registryKey the key of the registry
+		 * @param <V>         the type of values held in the registry
+		 * @return the registry if present, or {@code null} otherwise
+		 */
+		@Contract(pure = true)
+		@SuppressWarnings("unchecked")
+		public <V> Registry<V> get(RegistryKey<? extends Registry<V>> registryKey) {
+			return (Registry<V>) this.registries.get(registryKey);
+		}
+
+		/**
+		 * Registers the given game object into the given registry.
+		 *
+		 * @param registryKey the key of the registry to register into
+		 * @param id          the identifier of the game object to register
+		 * @param gameObject  the game object to register
+		 * @param <V>         the type of values held in the registry
+		 * @return the game object
+		 */
+		public <V> @NotNull V register(@NotNull RegistryKey<? extends Registry<V>> registryKey, @NotNull Identifier id,
+				@NotNull V gameObject) {
+			return Registry.register(this.get(registryKey), id, gameObject);
+		}
+	}
+}

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryEvents.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/RegistryEvents.java
@@ -16,10 +16,8 @@
 
 package org.quiltmc.qsl.registry.api.event;
 
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
-import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.registry.DynamicRegistryManager;
 import net.minecraft.util.registry.Registry;
 
@@ -64,11 +62,10 @@ public final class RegistryEvents {
 	 * the combined registry manager, and each layer holds different registries.
 	 * Use {@link DynamicRegistryManager#getOptional} to prevent crashes.
 	 */
-	@ApiStatus.Experimental
 	public static final Event<DynamicRegistrySetupCallback> DYNAMIC_REGISTRY_SETUP = Event.create(DynamicRegistrySetupCallback.class,
-			callbacks -> (resourceManager, registryManager) -> {
+			callbacks -> context -> {
 				for (var callback : callbacks) {
-					callback.onDynamicRegistrySetup(resourceManager, registryManager);
+					callback.onDynamicRegistrySetup(context);
 				}
 			}
 	);
@@ -109,7 +106,6 @@ public final class RegistryEvents {
 		void onAdded(RegistryEntryContext<V> context);
 	}
 
-	@ApiStatus.Experimental
 	@FunctionalInterface
 	public interface DynamicRegistrySetupCallback extends EventAwareListener {
 		/**
@@ -119,12 +115,11 @@ public final class RegistryEvents {
 		 * <strong>Important Note</strong>: The passed dynamic registry manager might not
 		 * contain the registry, as this event is invoked for each layer of
 		 * the combined registry manager, and each layer holds different registries.
-		 * Use {@link DynamicRegistryManager#getOptional} to prevent crashes.
+		 * Use {@link DynamicRegistryManager#getOptional} or other utility methods provided by the context object to prevent crashes.
 		 *
-		 * @param resourceManager the resource manager used to load the registries
-		 * @param registryManager the registry manager
+		 * @param context the dynamic registry manager setup context
 		 */
-		void onDynamicRegistrySetup(@NotNull ResourceManager resourceManager, @NotNull DynamicRegistryManager registryManager);
+		void onDynamicRegistrySetup(@NotNull DynamicRegistryManagerSetupContext context);
 	}
 
 	@FunctionalInterface

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/package-info.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/api/event/package-info.java
@@ -1,7 +1,8 @@
 /**
  * <h2>The Registry-related Events.</h2>
  * <p>
- * Some events to listen to registry additions are provided by the {@linkplain org.quiltmc.qsl.registry.api.event.RegistryEvents RegistryEvents} class.
+ * Some events to listen to registries such as additions or dynamic registries setup are provided
+ * by the {@linkplain org.quiltmc.qsl.registry.api.event.RegistryEvents RegistryEvents} class.
  * <p>
  * In addition to that an API for finer {@link org.quiltmc.qsl.registry.api.event.RegistryMonitor registry monitoring} is also provided.
  */

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/DynamicRegistryManagerSetupContextImpl.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/DynamicRegistryManagerSetupContextImpl.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.registry.impl;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.registry.DynamicRegistryManager;
+
+import org.quiltmc.qsl.registry.api.event.DynamicRegistryManagerSetupContext;
+
+@ApiStatus.Internal
+public record DynamicRegistryManagerSetupContextImpl(ResourceManager resourceManager, DynamicRegistryManager registryManager)
+		implements DynamicRegistryManagerSetupContext {
+}

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/mixin/C_ratuaukiMixin.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/mixin/C_ratuaukiMixin.java
@@ -31,6 +31,7 @@ import net.minecraft.util.registry.DynamicRegistryManager;
 import net.minecraft.util.registry.RegistryKey;
 
 import org.quiltmc.qsl.registry.api.event.RegistryEvents;
+import org.quiltmc.qsl.registry.impl.DynamicRegistryManagerSetupContextImpl;
 
 @Mixin(C_ratuauki.class)
 public class C_ratuaukiMixin {
@@ -42,7 +43,9 @@ public class C_ratuaukiMixin {
 	private static void onBeforeLoad(ResourceManager resourceManager, DynamicRegistryManager baseRegistryManager,
 			List<C_ratuauki.C_qpshoosu<?>> entries, CallbackInfoReturnable<DynamicRegistryManager.Frozen> cir,
 			Map<RegistryKey<?>, Exception> errors, List<?> list2, DynamicRegistryManager registryManager) {
-		RegistryEvents.DYNAMIC_REGISTRY_SETUP.invoker().onDynamicRegistrySetup(resourceManager, registryManager);
+		RegistryEvents.DYNAMIC_REGISTRY_SETUP.invoker().onDynamicRegistrySetup(
+				new DynamicRegistryManagerSetupContextImpl(resourceManager, registryManager)
+		);
 	}
 
 	@Inject(

--- a/library/worldgen/surface_rule/src/main/java/org/quiltmc/qsl/worldgen/surface_rule/impl/QuiltSurfaceRuleInitializer.java
+++ b/library/worldgen/surface_rule/src/main/java/org/quiltmc/qsl/worldgen/surface_rule/impl/QuiltSurfaceRuleInitializer.java
@@ -25,6 +25,7 @@ import net.minecraft.util.registry.Registry;
 import net.minecraft.world.gen.chunk.ChunkGeneratorSettings;
 import net.minecraft.world.gen.surfacebuilder.SurfaceRules;
 
+import org.quiltmc.qsl.registry.api.event.DynamicRegistryManagerSetupContext;
 import org.quiltmc.qsl.registry.api.event.RegistryEntryContext;
 import org.quiltmc.qsl.registry.api.event.RegistryEvents;
 import org.quiltmc.qsl.registry.api.event.RegistryMonitor;
@@ -34,9 +35,9 @@ import org.quiltmc.qsl.worldgen.surface_rule.mixin.ChunkGeneratorSettingsAccesso
 @ApiStatus.Internal
 public class QuiltSurfaceRuleInitializer implements RegistryEvents.DynamicRegistrySetupCallback {
 	@Override
-	public void onDynamicRegistrySetup(@NotNull ResourceManager resourceManager, @NotNull DynamicRegistryManager registryManager) {
-		registryManager.getOptional(Registry.CHUNK_GENERATOR_SETTINGS_KEY).ifPresent(registry -> {
-			RegistryMonitor.create(registry).forAll(context -> this.modifyChunkGeneratorSettings(context, resourceManager));
+	public void onDynamicRegistrySetup(@NotNull DynamicRegistryManagerSetupContext context) {
+		context.monitor(Registry.CHUNK_GENERATOR_SETTINGS_KEY, monitor -> {
+			monitor.forAll(ctx -> this.modifyChunkGeneratorSettings(ctx, context.resourceManager()));
 		});
 	}
 


### PR DESCRIPTION
DynamicRegistryManager setup event got implement very hastily to get surface rules API back up and running on 22w43a, but after looking at it and having to use it a second time but for the Biome API testmod, I'm definitely not happy with its current design.

So time to take our "snapshot is for experimentation" philosophy and apply it :P
Here's a second iteration of the event, this time with a context object which will make the event body more resistant to breakage.
It also introduces loads of helpers to deal with the DynamicRegistryManager more easily. You can find examples of it being used in the surfaces rules API and biome API testmods.