### PR TITLE
Add API for deriving tag keys using different types

### DIFF
--- a/library/data/tags/src/main/java/org/quiltmc/qsl/tag/api/QuiltTagKey.java
+++ b/library/data/tags/src/main/java/org/quiltmc/qsl/tag/api/QuiltTagKey.java
@@ -39,6 +39,17 @@ public interface QuiltTagKey<T> {
 	TagType type();
 
 	/**
+	 * Creates a new tag key based on another key but with a different type.
+	 *
+	 * @param tag  the tag key to base the new one on
+	 * @param type the type of the tag
+	 * @return the new tag key
+	 */
+	static <T> TagKey<T> of(TagKey<T> key, TagType type) {
+		return QuiltTagKey.of(key.registry(), key.id(), type);
+	}
+
+	/**
 	 * Creates a new tag key.
 	 *
 	 * @param registry the registry for which this tag key is valid

--- a/library/data/tags/src/testmod/java/org/quiltmc/qsl/tag/test/client/ClientTagsTestMod.java
+++ b/library/data/tags/src/testmod/java/org/quiltmc/qsl/tag/test/client/ClientTagsTestMod.java
@@ -41,6 +41,7 @@ public final class ClientTagsTestMod implements ClientModInitializer {
 	public static final TagKey<Block> TEST_CLIENT_BLOCK_TAG = QuiltTagKey.of(Registry.BLOCK_KEY, TagsTestMod.id("client_block_tag"), TagType.CLIENT_ONLY);
 	public static final TagKey<Biome> TEST_CLIENT_BIOME_TAG = QuiltTagKey.of(Registry.BIOME_KEY, TagsTestMod.id("client_biome_tag"), TagType.CLIENT_ONLY);
 	public static final TagKey<Item> TEST_DEFAULT_ITEM_TAG = QuiltTagKey.of(Registry.ITEM_KEY, TagsTestMod.id("default_item_tag"), TagType.CLIENT_FALLBACK);
+	public static final TagKey<Block> TEST_CLIENT_DERIVATIVE_BLOCK_TAG = QuiltTagKey.of(TagsTestMod.TEST_BLOCK_TAG, TagType.CLIENT_ONLY);
 
 	private static final Consumer<Text> FEEDBACK_CONSUMER = msg -> MinecraftClient.getInstance().player.sendMessage(msg, false);
 
@@ -66,6 +67,11 @@ public final class ClientTagsTestMod implements ClientModInitializer {
 					).then(literal("fallback_item")
 							.executes(context -> {
 								TagsTestMod.displayTag(TEST_DEFAULT_ITEM_TAG, Registry.ITEM, FEEDBACK_CONSUMER);
+								return 0;
+							})
+					).then(literal("derivative_block")
+							.executes(context -> {
+								TagsTestMod.displayTag(TEST_CLIENT_DERIVATIVE_BLOCK_TAG, Registry.BLOCK, FEEDBACK_CONSUMER);
 								return 0;
 							})
 					)

--- a/library/data/tags/src/testmod/resources/assets/quilt_tags_testmod/tags/blocks/block_tag.json
+++ b/library/data/tags/src/testmod/resources/assets/quilt_tags_testmod/tags/blocks/block_tag.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:light_blue_wool",
+    "minecraft:pink_wool",
+    "minecraft:white_wool"
+  ]
+}


### PR DESCRIPTION
This makes it easy to directly translate Fabric Client Tags' purpose (make a client fallback for any tags) to Quilt Tags API's way of doing things