### PR TITLE
Pass decrement `amount` value through to recipe remainder handler

### DIFF
--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/api/RecipeRemainderLogicHandler.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/api/RecipeRemainderLogicHandler.java
@@ -58,15 +58,24 @@ public interface RecipeRemainderLogicHandler {
 	 * Excess items that cannot be returned to a slot are dropped in the world.
 	 *
 	 * @param input the original item stack
+	 * @param amount the amount by which to decrease the stack
 	 * @param recipe the recipe being used
 	 * @param inventory the inventory
 	 * @param index the index of the original stack in the inventory
 	 * @param world the world
 	 * @param location the location to drop excess remainders
 	 */
+	@Contract(mutates = "param1, param4, param6")
+	static void handleRemainderForNonPlayerCraft(ItemStack input, int amount, @Nullable Recipe<?> recipe, DefaultedList<ItemStack> inventory, int index, World world, BlockPos location) {
+		RecipeRemainderLogicHandlerImpl.handleRemainderForNonPlayerCraft(input, amount, recipe, inventory, index, world, location);
+	}
+
+	/**
+	 * @see RecipeRemainderLogicHandler#handleRemainderForNonPlayerCraft(ItemStack, int, Recipe, DefaultedList, int, World, BlockPos)
+	 */
 	@Contract(mutates = "param1, param3, param5")
 	static void handleRemainderForNonPlayerCraft(ItemStack input, @Nullable Recipe<?> recipe, DefaultedList<ItemStack> inventory, int index, World world, BlockPos location) {
-		RecipeRemainderLogicHandlerImpl.handleRemainderForNonPlayerCraft(input, recipe, inventory, index, world, location);
+		handleRemainderForNonPlayerCraft(input, 1, recipe, inventory, index, world, location);
 	}
 
 	/**
@@ -74,11 +83,20 @@ public interface RecipeRemainderLogicHandler {
 	 * Excess items that cannot be returned to a slot are {@linkplain net.minecraft.entity.player.PlayerInventory#offerOrDrop(ItemStack) offered to the player or dropped}.
 	 *
 	 * @param slot the slot of the original stack
+	 * @param amount the amount by which to decrease the stack
 	 * @param recipe the recipe being used
 	 * @param player the player performing the craft
 	 */
+	@Contract(mutates = "param1, param4")
+	static void handleRemainderForScreenHandler(Slot slot, int amount, @Nullable Recipe<?> recipe, PlayerEntity player) {
+		RecipeRemainderLogicHandlerImpl.handleRemainderForScreenHandler(slot, amount, recipe, player);
+	}
+
+	/**
+	 * @see RecipeRemainderLogicHandler#handleRemainderForScreenHandler(Slot, int, Recipe, PlayerEntity)
+	 */
 	@Contract(mutates = "param1, param3")
 	static void handleRemainderForScreenHandler(Slot slot, @Nullable Recipe<?> recipe, PlayerEntity player) {
-		RecipeRemainderLogicHandlerImpl.handleRemainderForScreenHandler(slot, recipe, player);
+		handleRemainderForScreenHandler(slot, 1, recipe, player);
 	}
 }

--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/impl/RecipeRemainderLogicHandlerImpl.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/impl/RecipeRemainderLogicHandlerImpl.java
@@ -77,21 +77,21 @@ public final class RecipeRemainderLogicHandlerImpl implements RecipeRemainderLog
 	}
 
 	@Contract(mutates = "param1")
-	private static ItemStack decrementWithRemainder(ItemStack original, @Nullable Recipe<?> recipe) {
+	private static ItemStack decrementWithRemainder(ItemStack original, int amount, @Nullable Recipe<?> recipe) {
 		if (original.isEmpty()) {
 			return ItemStack.EMPTY;
 		}
 
 		ItemStack remainder = RecipeRemainderLogicHandler.getRemainder(original, recipe);
 
-		original.decrement(1);
+		original.decrement(amount);
 
 		return remainder;
 	}
 
-	@Contract(mutates = "param1, param3, param5")
-	public static void handleRemainderForNonPlayerCraft(ItemStack input, @Nullable Recipe<?> recipe, DefaultedList<ItemStack> inventory, int index, World world, BlockPos location) {
-		ItemStack remainder = decrementWithRemainder(input, recipe);
+	@Contract(mutates = "param1, param4, param6")
+	public static void handleRemainderForNonPlayerCraft(ItemStack input, int amount, @Nullable Recipe<?> recipe, DefaultedList<ItemStack> inventory, int index, World world, BlockPos location) {
+		ItemStack remainder = decrementWithRemainder(input, amount, recipe);
 
 		if (remainder.isEmpty()) {
 			return;
@@ -102,9 +102,9 @@ public final class RecipeRemainderLogicHandlerImpl implements RecipeRemainderLog
 		}
 	}
 
-	@Contract(mutates = "param1, param3")
-	public static void handleRemainderForScreenHandler(Slot slot, @Nullable Recipe<?> recipe, PlayerEntity player) {
-		ItemStack remainder = decrementWithRemainder(slot.getStack(), recipe);
+	@Contract(mutates = "param1, param4")
+	public static void handleRemainderForScreenHandler(Slot slot, int amount, @Nullable Recipe<?> recipe, PlayerEntity player) {
+		ItemStack remainder = decrementWithRemainder(slot.getStack(), amount, recipe);
 
 		if (remainder.isEmpty()) {
 			return;

--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/impl/RecipeRemainderLogicHandlerImpl.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/impl/RecipeRemainderLogicHandlerImpl.java
@@ -66,7 +66,9 @@ public final class RecipeRemainderLogicHandlerImpl implements RecipeRemainderLog
 	 */
 	@Contract(mutates = "param1, param2")
 	private static boolean tryMergeStacks(ItemStack base, ItemStack remainder) {
-		if (!ItemStack.canCombine(base, remainder)) {
+		if (remainder.isEmpty()) {
+			return true;
+		} else if (!ItemStack.canCombine(base, remainder)) {
 			return false;
 		}
 
@@ -93,10 +95,6 @@ public final class RecipeRemainderLogicHandlerImpl implements RecipeRemainderLog
 	public static void handleRemainderForNonPlayerCraft(ItemStack input, int amount, @Nullable Recipe<?> recipe, DefaultedList<ItemStack> inventory, int index, World world, BlockPos location) {
 		ItemStack remainder = decrementWithRemainder(input, amount, recipe);
 
-		if (remainder.isEmpty()) {
-			return;
-		}
-
 		if (!tryReturnItemToInventory(remainder, inventory, index)) {
 			ItemScatterer.spawn(world, location.getX(), location.getY(), location.getZ(), remainder);
 		}
@@ -105,10 +103,6 @@ public final class RecipeRemainderLogicHandlerImpl implements RecipeRemainderLog
 	@Contract(mutates = "param1, param4")
 	public static void handleRemainderForScreenHandler(Slot slot, int amount, @Nullable Recipe<?> recipe, PlayerEntity player) {
 		ItemStack remainder = decrementWithRemainder(slot.getStack(), amount, recipe);
-
-		if (remainder.isEmpty()) {
-			return;
-		}
 
 		if (!tryReturnItemToSlot(remainder, slot)) {
 			player.getInventory().offerOrDrop(remainder);

--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/AbstractFurnaceBlockEntityMixin.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/AbstractFurnaceBlockEntityMixin.java
@@ -70,7 +70,7 @@ public abstract class AbstractFurnaceBlockEntityMixin extends BlockEntity implem
 
 	@SuppressWarnings("ConstantConditions")
 	@Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;decrement(I)V"))
-	private static void setFuelRemainder(ItemStack fuelStack, int count, World world, BlockPos pos, BlockState state, AbstractFurnaceBlockEntity blockEntity) {
+	private static void setFuelRemainder(ItemStack fuelStack, int amount, World world, BlockPos pos, BlockState state, AbstractFurnaceBlockEntity blockEntity) {
 		AbstractFurnaceBlockEntityMixin cast = ((AbstractFurnaceBlockEntityMixin) (BlockEntity) blockEntity);
 
 		Recipe<?> recipe;
@@ -82,6 +82,7 @@ public abstract class AbstractFurnaceBlockEntityMixin extends BlockEntity implem
 
 		RecipeRemainderLogicHandler.handleRemainderForNonPlayerCraft(
 				fuelStack,
+				amount,
 				recipe,
 				cast.inventory,
 				FUEL_SLOT,
@@ -99,6 +100,7 @@ public abstract class AbstractFurnaceBlockEntityMixin extends BlockEntity implem
 	private static void setInputRemainder(ItemStack inputStack, int amount, Recipe<?> recipe, DefaultedList<ItemStack> inventory, int count) {
 		RecipeRemainderLogicHandler.handleRemainderForNonPlayerCraft(
 				inputStack,
+				amount,
 				recipe,
 				inventory,
 				INPUT_SLOT,

--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/BrewingStandBlockEntityMixin.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/BrewingStandBlockEntityMixin.java
@@ -42,6 +42,7 @@ public class BrewingStandBlockEntityMixin {
 	private static void applyRecipeRemainder(ItemStack ingredient, int amount, World world, BlockPos pos, DefaultedList<ItemStack> inventory) {
 		RecipeRemainderLogicHandler.handleRemainderForNonPlayerCraft(
 				ingredient,
+				amount,
 				null,
 				inventory,
 				INGREDIENT_SLOT,

--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/LoomOutputSlotMixin.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/LoomOutputSlotMixin.java
@@ -37,6 +37,7 @@ public class LoomOutputSlotMixin extends Slot {
 	public ItemStack getRecipeRemainder(Slot slot, int amount, PlayerEntity player, ItemStack resultStack) {
 		RecipeRemainderLogicHandler.handleRemainderForScreenHandler(
 				slot,
+				amount,
 				null,
 				player
 		);

--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/SmithingScreenHandlerMixin.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/SmithingScreenHandlerMixin.java
@@ -47,12 +47,13 @@ public abstract class SmithingScreenHandlerMixin extends ForgingScreenHandler {
 		super(screenHandlerType, i, playerInventory, screenHandlerContext);
 	}
 
-	@Redirect(method = "onTakeOutput", at = @At(value = "INVOKE", target = "Lnet/minecraft/screen/SmithingScreenHandler;decrementStack(I)V"))
-	private void applyRecipeRemainder(SmithingScreenHandler instance, int slot, PlayerEntity player, ItemStack stack) {
+	@Redirect(method = "decrementStack", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;decrement(I)V"))
+	private void applyRecipeRemainder(ItemStack instance, int amount, int slot) {
 		RecipeRemainderLogicHandler.handleRemainderForScreenHandler(
 				this.getSlot(slot),
+				amount,
 				this.currentRecipe,
-				player
+				this.player
 		);
 	}
 

--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/StonecutterOutputSlotMixin.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/StonecutterOutputSlotMixin.java
@@ -16,20 +16,18 @@
 
 package org.quiltmc.qsl.item.setting.mixin.recipe_remainder;
 
-import org.spongepowered.asm.mixin.Dynamic;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
-
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.Recipe;
 import net.minecraft.screen.StonecutterScreenHandler;
 import net.minecraft.screen.slot.Slot;
-
 import org.quiltmc.qsl.item.setting.api.RecipeRemainderLogicHandler;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(targets = {"net.minecraft.screen.StonecutterScreenHandler$C_biccipxg"})
 public class StonecutterOutputSlotMixin extends Slot {
@@ -53,6 +51,6 @@ public class StonecutterOutputSlotMixin extends Slot {
 				player
 		);
 
-		return slot.getStack();
+		return new ItemStack(slot.getStack().getItem(), amount);
 	}
 }

--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/StonecutterOutputSlotMixin.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/StonecutterOutputSlotMixin.java
@@ -48,6 +48,7 @@ public class StonecutterOutputSlotMixin extends Slot {
 
 		RecipeRemainderLogicHandler.handleRemainderForScreenHandler(
 				slot,
+				amount,
 				recipe,
 				player
 		);

--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/StonecutterOutputSlotMixin.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/StonecutterOutputSlotMixin.java
@@ -18,6 +18,7 @@ package org.quiltmc.qsl.item.setting.mixin.recipe_remainder;
 
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.Recipe;
 import net.minecraft.screen.StonecutterScreenHandler;
@@ -43,6 +44,8 @@ public class StonecutterOutputSlotMixin extends Slot {
 	public ItemStack getRecipeRemainder(Slot slot, int amount, PlayerEntity player, ItemStack stack) {
 		int selectedRecipe = this.field_17639.getSelectedRecipe();
 		Recipe<?> recipe = selectedRecipe != -1 ? this.field_17639.getAvailableRecipes().get(selectedRecipe) : null;
+		Item inputItem = slot.getStack().getItem();
+		int inputCount = slot.getStack().getCount();
 
 		RecipeRemainderLogicHandler.handleRemainderForScreenHandler(
 				slot,
@@ -51,6 +54,6 @@ public class StonecutterOutputSlotMixin extends Slot {
 				player
 		);
 
-		return new ItemStack(slot.getStack().getItem(), amount);
+		return new ItemStack(inputItem, Math.min(amount, inputCount));
 	}
 }


### PR DESCRIPTION
Closes #218

This correctly handles the `amount` parameter from the output slot mixins instead of ignoring it. This fixes mods that alter the amount of items consumed by a recipe through mixins (or some potential future API).