### PR TITLE
Change Multipart Entity API's "rotate" methods to work as intended

### DIFF
--- a/library/entity/multipart/src/main/java/org/quiltmc/qsl/entity/multipart/api/AbstractEntityPart.java
+++ b/library/entity/multipart/src/main/java/org/quiltmc/qsl/entity/multipart/api/AbstractEntityPart.java
@@ -184,9 +184,9 @@ public abstract class AbstractEntityPart<E extends Entity> extends Entity implem
 	 * @param pitch the rotation about x-axis in degrees
 	 * @param yaw   the rotation about y-axis in degrees
 	 */
-	public void rotate(Vec3d pivot, float pitch, float yaw) {
+	public void rotate(Vec3d pivot, float pitch, float yaw, boolean degrees) {
 		this.setPivot(pivot);
-		this.rotate(pitch, yaw, true);
+		this.rotate(pitch, yaw, degrees);
 	}
 
 	/**
@@ -201,6 +201,21 @@ public abstract class AbstractEntityPart<E extends Entity> extends Entity implem
 		rel = rel.rotateX(-pitch * (degrees ? (float)Math.PI/180f : 1)).rotateY(-yaw * (degrees ? (float)Math.PI/180f : 1));
 		Vec3d transformedPos = this.getAbsolutePivot().subtract(this.getAbsolutePosition()).add(rel);
 		this.move(transformedPos);
+	}
+	/**
+	 * @deprecated  Use {@link #rotate(float, float, boolean)} instead.
+	 */
+	@Deprecated
+	public void rotate(float pitch, float yaw, float roll) {
+		rotate(pitch, yaw, false);
+	}
+	/**
+	 * @deprecated  Use {@link #rotate(Vec3d, float, float, boolean)} instead.
+	 */
+	@Deprecated
+	public void rotate(Vec3d pivot, float pitch, float yaw, float roll) {
+		this.setPivot(pivot);
+		rotate(pitch, yaw, false);
 	}
 
 	/**

--- a/library/entity/multipart/src/main/java/org/quiltmc/qsl/entity/multipart/api/AbstractEntityPart.java
+++ b/library/entity/multipart/src/main/java/org/quiltmc/qsl/entity/multipart/api/AbstractEntityPart.java
@@ -202,6 +202,7 @@ public abstract class AbstractEntityPart<E extends Entity> extends Entity implem
 		Vec3d transformedPos = this.getAbsolutePivot().subtract(this.getAbsolutePosition()).add(rel);
 		this.move(transformedPos);
 	}
+
 	/**
 	 * @deprecated  Use {@link #rotate(float, float, boolean)} instead.
 	 */

--- a/library/entity/multipart/src/main/java/org/quiltmc/qsl/entity/multipart/api/AbstractEntityPart.java
+++ b/library/entity/multipart/src/main/java/org/quiltmc/qsl/entity/multipart/api/AbstractEntityPart.java
@@ -209,6 +209,7 @@ public abstract class AbstractEntityPart<E extends Entity> extends Entity implem
 	public void rotate(float pitch, float yaw, float roll) {
 		rotate(pitch, yaw, false);
 	}
+
 	/**
 	 * @deprecated  Use {@link #rotate(Vec3d, float, float, boolean)} instead.
 	 */

--- a/library/entity/multipart/src/main/java/org/quiltmc/qsl/entity/multipart/api/AbstractEntityPart.java
+++ b/library/entity/multipart/src/main/java/org/quiltmc/qsl/entity/multipart/api/AbstractEntityPart.java
@@ -181,28 +181,25 @@ public abstract class AbstractEntityPart<E extends Entity> extends Entity implem
 	 * Rotates this {@link AbstractEntityPart} about the pivot point with the given rotation.
 	 *
 	 * @param pivot the pivot point to rotate about in relative coordinates
-	 * @param pitch the rotation about z-axis in degrees
+	 * @param pitch the rotation about x-axis in degrees
 	 * @param yaw   the rotation about y-axis in degrees
-	 * @param roll  the rotation about x-axis in degrees
 	 */
-	public void rotate(Vec3d pivot, float pitch, float yaw, float roll) {
+	public void rotate(Vec3d pivot, float pitch, float yaw) {
 		this.setPivot(pivot);
-		this.rotate(pitch, yaw, roll);
+		this.rotate(pitch, yaw, true);
 	}
 
 	/**
 	 * Rotates this {@link AbstractEntityPart} about its {@link AbstractEntityPart#pivot pivot point} with the given rotation.
 	 *
-	 * @param pitch the rotation about z-axis in degrees
-	 * @param yaw   the rotation about y-axis in degrees
-	 * @param roll  the rotation about x-axis in degrees
+	 * @param pitch the rotation about the x-axis
+	 * @param yaw   the rotation about the y-axis
+	 * @param degrees whether the rotation should be done in degrees or radians
 	 */
-	public void rotate(float pitch, float yaw, float roll) {
-		Vec3f relativePos = new Vec3f(this.getAbsolutePosition().subtract(this.getAbsolutePivot()));
-		relativePos.rotate(new Quaternion(-roll, -yaw, -pitch, true));
-		var transformedPos = this.getAbsolutePivot().subtract(this.getAbsolutePosition())
-				.add(relativePos.getX(), relativePos.getY(), relativePos.getZ());
-
+	public void rotate(float pitch, float yaw, boolean degrees) {
+		Vec3d rel = this.getAbsolutePosition().subtract(this.getAbsolutePivot());
+		rel = rel.rotateX(-pitch * (degrees ? (float)Math.PI/180f : 1)).rotateY(-yaw * (degrees ? (float)Math.PI/180f : 1));
+		Vec3d transformedPos = this.getAbsolutePivot().subtract(this.getAbsolutePosition()).add(rel);
 		this.move(transformedPos);
 	}
 
@@ -225,7 +222,7 @@ public abstract class AbstractEntityPart<E extends Entity> extends Entity implem
 	}
 
 	/**
-	 * Sets the point to {@link AbstractEntityPart#rotate(float, float, float) rotate} about.
+	 * Sets the point to {@link AbstractEntityPart#rotate(float, float, boolean) rotate} about.
 	 *
 	 * @param pivot the pivot point
 	 */
@@ -234,7 +231,7 @@ public abstract class AbstractEntityPart<E extends Entity> extends Entity implem
 	}
 
 	/**
-	 * Sets the point to {@link AbstractEntityPart#rotate(float, float, float) rotate} about.
+	 * Sets the point to {@link AbstractEntityPart#rotate(float, float, boolean) rotate} about.
 	 *
 	 * @param x the x coordinate of the pivot point
 	 * @param y the y coordinate of the pivot point

--- a/library/entity/multipart/src/main/java/org/quiltmc/qsl/entity/multipart/api/AbstractEntityPart.java
+++ b/library/entity/multipart/src/main/java/org/quiltmc/qsl/entity/multipart/api/AbstractEntityPart.java
@@ -181,8 +181,9 @@ public abstract class AbstractEntityPart<E extends Entity> extends Entity implem
 	 * Rotates this {@link AbstractEntityPart} about the pivot point with the given rotation.
 	 *
 	 * @param pivot the pivot point to rotate about in relative coordinates
-	 * @param pitch the rotation about x-axis in degrees
-	 * @param yaw   the rotation about y-axis in degrees
+	 * @param pitch   the rotation about x-axis
+	 * @param yaw     the rotation about y-axis
+	 * @param degrees whether the rotation should be done in degrees or radians
 	 */
 	public void rotate(Vec3d pivot, float pitch, float yaw, boolean degrees) {
 		this.setPivot(pivot);

--- a/library/entity/multipart/src/testmod/java/org/quiltmc/qsl/entity/multipart/test/mixin/CreeperEntityMixin.java
+++ b/library/entity/multipart/src/testmod/java/org/quiltmc/qsl/entity/multipart/test/mixin/CreeperEntityMixin.java
@@ -48,7 +48,7 @@ public abstract class CreeperEntityMixin extends HostileEntity implements Multip
 		super.tickMovement();
 		var cycle = 0.5f + (age % 100) / 100f;
 		this.secretHitbox.scale(cycle);
-		this.secretHitbox.rotate(this.getPitch(), this.getHeadYaw(), 0.0f);
+		this.secretHitbox.rotate(this.getPitch(), this.getHeadYaw(), true);
 	}
 
 	@Override


### PR DESCRIPTION
This PR changes the rotate() methods of AbstractMultipartEntity to rotate the vectors via pitch and yaw only, which also fixes the bug where pitch and yaw rotations would not stack (as result of using quaternions, presumably).
It addionally adds the option to switch between degrees and radians without having to use *(float)Math.PI/180f every time.