### PR TITLE
Fix typo in RegistrySync that sends and receives RESTORE for APPLY.

### DIFF
--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/sync/ServerPackets.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/sync/ServerPackets.java
@@ -26,7 +26,7 @@ import net.minecraft.util.Identifier;
  */
 @ApiStatus.Internal
 public final class ServerPackets {
-	public static final IntSet SUPPORTED_VERSIONS = IntSet.of(1);
+	public static final IntSet SUPPORTED_VERSIONS = IntSet.of(1, 2);
 
 	/**
 	 * Starts registry sync.

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/sync/ServerRegistrySyncNetworkHandler.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/sync/ServerRegistrySyncNetworkHandler.java
@@ -124,7 +124,7 @@ public final class ServerRegistrySyncNetworkHandler implements ServerPlayPacketL
 		switch (packet.getParameter()) {
 			case HELLO_PING -> {
 				if (this.syncVersion != -1) {
-					ServerRegistrySync.sendSyncPackets(this.connection, this.player);
+					ServerRegistrySync.sendSyncPackets(this.connection, this.player, this.syncVersion);
 				} else if (ServerRegistrySync.supportFabric && ((ChannelInfoHolder) this.connection).getPendingChannelsNames().contains(ServerFabricRegistrySync.ID)) {
 					ServerFabricRegistrySync.sendSyncPackets(this.connection);
 					this.syncVersion = -2;


### PR DESCRIPTION
Note: This requires a version bump and backward compatibility code to avoid breaking the client by the server not sending expected data. This won't break the server as the server is an authority, and won't require either the server or client to update as is with the compatibility code in place.

Tested with an older QSL server and client without this patch, and registry syncing still functions as intended.