### PR TITLE
Properly load default language entries from mods and Minecraft.

### DIFF
--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/server/LanguageMixin.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/server/LanguageMixin.java
@@ -34,8 +34,8 @@ public class LanguageMixin {
 			method = "create",
 			at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableMap$Builder;build()Lcom/google/common/collect/ImmutableMap;")
 	)
-	private static ImmutableMap<String, String> create(ImmutableMap.Builder<String, String> cir) {
-		var map = new Object2ObjectOpenHashMap<>(cir.buildOrThrow());
+	private static ImmutableMap<String, String> create(ImmutableMap.Builder<String, String> builder) {
+		var map = new Object2ObjectOpenHashMap<>(builder.buildOrThrow());
 		ResourceLoaderImpl.appendLanguageEntries(map);
 		return ImmutableMap.copyOf(map);
 	}

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/server/LanguageMixin.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/mixin/server/LanguageMixin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.qsl.resource.loader.mixin.server;
+
+import com.google.common.collect.ImmutableMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.util.Language;
+
+import org.quiltmc.loader.api.minecraft.DedicatedServerOnly;
+import org.quiltmc.qsl.resource.loader.impl.ResourceLoaderImpl;
+
+@DedicatedServerOnly
+@Mixin(Language.class)
+public class LanguageMixin {
+	@Redirect(
+			method = "create",
+			at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableMap$Builder;build()Lcom/google/common/collect/ImmutableMap;")
+	)
+	private static ImmutableMap<String, String> create(ImmutableMap.Builder<String, String> cir) {
+		var map = new Object2ObjectOpenHashMap<>(cir.buildOrThrow());
+		ResourceLoaderImpl.appendLanguageEntries(map);
+		return ImmutableMap.copyOf(map);
+	}
+}

--- a/library/core/resource_loader/src/main/resources/quilt_resource_loader.mixins.json
+++ b/library/core/resource_loader/src/main/resources/quilt_resource_loader.mixins.json
@@ -19,16 +19,19 @@
     "server.MainMixin"
   ],
   "client": [
-    "client.IntegratedServerLoaderMixin",
     "client.ClientBuiltinResourcePackProviderMixin",
     "client.CreateWorldScreenMixin",
     "client.EntryListWidgetAccessor",
     "client.FontManagerResourceReloadListenerMixin",
     "client.GameOptionsMixin",
+    "client.IntegratedServerLoaderMixin",
     "client.KeyedClientResourceReloaderMixin",
     "client.MinecraftClientMixin",
     "client.PackScreenMixin",
     "client.ResourcePackEntryAccessor"
+  ],
+  "server": [
+    "server.LanguageMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This fixes dedicated servers not having any language entries loaded.