### PR TITLE
Switch to using loader.api.CachedFileSystem rather than loader internals.

### DIFF
--- a/build-logic/src/main/java/qsl/internal/Versions.java
+++ b/build-logic/src/main/java/qsl/internal/Versions.java
@@ -43,7 +43,7 @@ public final class Versions {
 	/**
 	 * The version of Quilt Loader to use.
 	 */
-	public static final String LOADER_VERSION = "0.17.6";
+	public static final String LOADER_VERSION = "0.17.7";
 
 	/**
 	 * The target Java version.

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModNioResourcePack.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModNioResourcePack.java
@@ -40,7 +40,7 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 
 import org.quiltmc.loader.api.ModMetadata;
-import org.quiltmc.loader.impl.filesystem.QuiltJoinedFileSystem;
+import org.quiltmc.loader.api.CachedFileSystem;
 import org.quiltmc.qsl.base.api.util.TriState;
 import org.quiltmc.qsl.resource.loader.api.QuiltResourcePack;
 import org.quiltmc.qsl.resource.loader.api.ResourcePackActivationType;
@@ -96,8 +96,8 @@ public class ModNioResourcePack extends AbstractFileResourcePack implements Quil
 		}
 
 		/* Cache */
-		if (DISABLE_CACHING || path.getFileSystem() == DEFAULT_FILESYSTEM || path.getFileSystem() instanceof QuiltJoinedFileSystem) {
-			// The default file system means it's on-disk files that may change, and QuiltJoinedFileSystem is usually used for dev envs too.
+		if (DISABLE_CACHING || path.getFileSystem() == DEFAULT_FILESYSTEM || path.getFileSystem() instanceof CachedFileSystem cached && !cached.isPermanentlyReadOnly()) {
+			// The default file system means it's on-disk files that may change
 			this.cache = new ResourceAccess(this.io);
 		} else {
 			// Allows caching for mods that don't have mutable resources.


### PR DESCRIPTION
Since `JoinedFileSystem` might be used for read-only mods in the future, and mutable mods might not use `JoinedFileSystem` - however calling [`CachedFileSystem`](https://github.com/QuiltMC/quilt-loader/blob/develop/src/main/java/org/quiltmc/loader/api/CachedFileSystem.java#L21-L26).[`isPermanentlyReadOnly()`](https://github.com/QuiltMC/quilt-loader/blob/develop/src/main/java/org/quiltmc/loader/api/CachedFileSystem.java#L28-L33) will ensure mutable mods never get cached, and immutable mods will always get cached.