### PR TITLE
Revise PR policy and conventions: Round 2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Everything within this section is the definitions for the actual PR policy follo
 
 ### Other
 
-If the determined FCP length is judged to be inadequate for one or more PRs, a member of the QSL Core team may either shorten or extend their FCPs, provided that no other member objects it. This applies to both PRs that are yet to begin its FCP and to PRs whose FCP is already in motion.
+If the determined FCP length is judged to be inadequate for one or more PRs, a member of the QSL Core team may either shorten, extend, or skip their FCPs, provided that no other member objects it. This applies to both PRs that are yet to begin its FCP and to PRs whose FCP is already in motion.
 
 Trivial fixes that do not require review (e.g. typos) are exempt from this policy. QSL team members should double check with other members of the team on Discord before pushing a commit or merging a PR without going through this process.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,15 +27,6 @@ In the event that there is no-one available on a library team to review your PR,
 ## PR Policy Definitions
 Everything within this section is the definitions for the actual PR policy followed by the QSL team, in accordance with [RFC 39](https://github.com/QuiltMC/rfcs/blob/master/structure/0039-pr-policy.md)
 
-### `T: major`
-
-**Description**: Used for pull requests whose impact means that it requires a more careful reviewing.
-
-**Required Approvals**: 3
-- At least 1 approval must come directly from each library team whose code the pull request modifies.
-
-**Final Comment Period**: 7 days
-
 ### `T: new API`
 
 **Description**: Used for pull requests that add new APIs to QSL, defined as anything in a `$modulename.api` package or subfolders.
@@ -73,6 +64,8 @@ Everything within this section is the definitions for the actual PR policy follo
 **Final Comment Period**: N/A
 
 ### Other
+
+If the determined FCP length is judged to be inadequate for one or more PRs, a member of the QSL Core team may either shorten or extend their FCPs, provided that no other member objects it. This applies to both PRs that are yet to begin its FCP and to PRs whose FCP is already in motion.
 
 Trivial fixes that do not require review (e.g. typos) are exempt from this policy. QSL team members should double check with other members of the team on Discord before pushing a commit or merging a PR without going through this process.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,7 +249,7 @@ Note that `.` from abbreviations, such as `i.e.`, count.
 The `$` character may be used in mixins to mark a semantic separation in the name, in other words it allows to separate
 the actual name of the variable and the namespace.
 
-All mixin fields and methods must be prefixed with `quilt$` in order to aid with debugging.
+All mixin fields and methods (including those from duck interfaces) must be prefixed with `quilt$` in order to aid with debugging.
 
 In the case of a pseudo-local variable (a field used briefly to pass around a local variable of a method between 2
 injections of said method), the field should be named with the namespace first, then the name of the injected method,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,15 @@ In the event that there is no-one available on a library team to review your PR,
 ## PR Policy Definitions
 Everything within this section is the definitions for the actual PR policy followed by the QSL team, in accordance with [RFC 39](https://github.com/QuiltMC/rfcs/blob/master/structure/0039-pr-policy.md)
 
+### `T: major`
+
+**Description**: Used for pull requests whose impact means that it requires a more careful reviewing.
+
+**Required Approvals**: 3
+- At least 1 approval must come directly from each library team whose code the pull request modifies.
+
+**Final Comment Period**: 7 days
+
 ### `T: new API`
 
 **Description**: Used for pull requests that add new APIs to QSL, defined as anything in a `$modulename.api` package or subfolders.
@@ -34,11 +43,20 @@ Everything within this section is the definitions for the actual PR policy follo
 **Required Approvals**: 2
 - At least 1 approval must come directly from each library team whose code the pull request modifies.
 
-**Final Comment Period**: 7 days
+**Final Comment Period**: 5 days
 
 ### `T: refactor`
 
 **Description**: Used for pull requests that make internal refactors and do not change any API, such as bugfixes or buildscript changes.
+
+**Required Approvals**: 2
+- At least 1 approval must come directly from each library team whose code the pull request modifies.
+
+**Final Comment Period**: 3 days
+
+### `T: documentation`
+
+**Description**: Used for pull requests that make additions or revisions to the codebase's documentation.
 
 **Required Approvals**: 2
 - At least 1 approval must come directly from each library team whose code the pull request modifies.
@@ -60,7 +78,7 @@ Trivial fixes that do not require review (e.g. typos) are exempt from this polic
 
 PRs that do not fit under any of these categories but are not "trivial fixes" are merged at the consensus of the QSL Core team, using whatever criteria they determine to be appropriate. (For example, amending the PR policy may require every core member to approve, and have a 1-week FCP).
 
-In the event that a QSL subteam has less than two active members, a QSL Core team member may waive the requirement for that team to review a PR.
+In the event that a QSL subteam, excluding the PR author, has less than two active members, a QSL Core team member may waive the requirement for that team to review a PR.
 
 *This is only a summary of QSL's PR process and an explanation of QSL-specific exceptions to it. For exact definitions and more information, see [RFC 39](https://github.com/QuiltMC/rfcs/blob/master/structure/0039-pr-policy.md).*
 
@@ -231,7 +249,7 @@ Note that `.` from abbreviations, such as `i.e.`, count.
 The `$` character may be used in mixins to mark a semantic separation in the name, in other words it allows to separate
 the actual name of the variable and the namespace.
 
-`@Unique` fields must be prefixed with `quilt$`, but `@Unique` methods don't need prefixes.
+All mixin fields and methods must be prefixed with `quilt$` in order to aid with debugging.
 
 In the case of a pseudo-local variable (a field used briefly to pass around a local variable of a method between 2
 injections of said method), the field should be named with the namespace first, then the name of the injected method,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Everything within this section is the definitions for the actual PR policy follo
 
 ### Other
 
-If the determined FCP length is judged to be inadequate for one or more PRs, a member of the QSL Core team may either shorten, extend, or skip their FCPs, provided that no other member objects it. This applies to both PRs that are yet to begin its FCP and to PRs whose FCP is already in motion.
+If the determined FCP length is judged to be inadequate for one or more PRs, a member of the QSL Core team may either shorten, extend, or skip their FCPs, provided that all other members approve it. This applies to both PRs that are yet to begin its FCP and to PRs whose FCP is already in motion.
 
 Trivial fixes that do not require review (e.g. typos) are exempt from this policy. QSL team members should double check with other members of the team on Discord before pushing a commit or merging a PR without going through this process.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Everything within this section is the definitions for the actual PR policy follo
 
 ### Other
 
-If the determined FCP length is judged to be inadequate for one or more PRs, a member of the QSL Core team may either shorten, extend, or skip their FCPs, provided that all other members approve it. This applies to both PRs that are yet to begin its FCP and to PRs whose FCP is already in motion.
+If the determined FCP length is judged to be inadequate for one or more PRs, at least two members of the QSL Core team may agree to either shorten, extend, or skip them, provided that all QSL Core team members had a reasonable chance to respond. This applies to both PRs that are yet to begin its FCP and to PRs whose FCP is already in motion.
 
 Trivial fixes that do not require review (e.g. typos) are exempt from this policy. QSL team members should double check with other members of the team on Discord before pushing a commit or merging a PR without going through this process.
 


### PR DESCRIPTION
I'm trying [this](https://github.com/QuiltMC/quilt-standard-libraries/pull/195) again, because once again, the PR Policy is harming us; This formalizes many of the things adopted in the meantime, like the `t: documentation` and the Ennui Manuever™ while also erasing few Lego bricks.

I believe that there are possible changes to be done here, like restructuring the QSL team and making FCPs easier to test, but those are bigger changes to be done later; This should be enough for now.

Recycling the original PR description:

---

This PR does the following:
 - Formalizes `t: documentation` in the PR policy
 - ~~Creates `t: major` for PRs that are, well, major; It requires 3 approvals and has a FCP of 7 days~~
   - I've judged `t: major` as unnecessary, and considering my own experiences, the following proposal would be better:
 - (New!) Formalizes the Ennui Manuever™, which allows for a QSL Core team member to modify the FCP length for specific PRs, as long as other core members approve it
 - Reduces `t: new API`'s FCP length to 5 days, 'cause yeah, 7 was way too much...
 - Expands the team approval weaver to exclude the PR author if they are in the team
 - Formalizes the "`quilt$` everywhere" convention in the conventions
 
 [Preview](https://github.com/EnnuiL/quilt-standard-libraries/blob/update-pr-policy/CONTRIBUTING.md)