### PR TITLE
Remove Unneccessary Brackets

### DIFF
--- a/library/gui/screen/src/main/java/org/quiltmc/qsl/screen/api/client/QuiltScreen.java
+++ b/library/gui/screen/src/main/java/org/quiltmc/qsl/screen/api/client/QuiltScreen.java
@@ -46,17 +46,17 @@ public interface QuiltScreen {
 	List<ClickableWidget> getButtons();
 
 	/**
-	 * {@return the screen's item renderer}
+	 * @return the screen's item renderer
 	 */
 	ItemRenderer getItemRenderer();
 
 	/**
-	 * {@return the screen's text renderer}
+	 * @return the screen's text renderer
 	 */
 	TextRenderer getTextRenderer();
 
 	/**
-	 * {@return the Minecraft client instance}
+	 * @return the Minecraft client instance
 	 */
 	MinecraftClient getClient();
 }


### PR DESCRIPTION
This bug may have been repeated countless times, but here's a fix for just the first occurrence I noticed.

Fixes this JavaDoc rendering bug:
![JavaDoc bug](https://user-images.githubusercontent.com/30361266/215315046-dae54b9c-2c82-4b14-85cc-dad0ddd1c6f5.png "JavaDoc shows first the literal text '@return ...' and then the rendered version 'Returns: ...'")