### PR TITLE
Set the default mixin priority to `500`.

### DIFF
--- a/library/block/block_content_registry/src/main/resources/quilt_block_content_registry.mixins.json
+++ b/library/block/block_content_registry/src/main/resources/quilt_block_content_registry.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.block.content.registry.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "AxeItemMixin",
     "EnchantingTableBlockMixin",

--- a/library/block/block_entity/src/main/resources/quilt_block_entity.mixins.json
+++ b/library/block/block_entity/src/main/resources/quilt_block_entity.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.block.entity.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "BlockEntityTypeMixin"
   ],

--- a/library/block/block_entity/src/testmod/resources/quilt_block_entity_testmod.mixins.json
+++ b/library/block/block_entity/src/testmod/resources/quilt_block_entity_testmod.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.block.entity.test.client.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "client": [
     "BlockColorsMixin"
   ],

--- a/library/block/block_extensions/src/main/resources/quilt_block_extensions.mixins.json
+++ b/library/block/block_extensions/src/main/resources/quilt_block_extensions.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.block.extensions.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "AbstractBlockAccessor",
     "AbstractBlockSettingsAccessor",

--- a/library/core/crash_info/src/main/resources/quilt_crash_info.mixins.json
+++ b/library/core/crash_info/src/main/resources/quilt_crash_info.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.crash.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "BlockEntityMixin",
     "CrashReportMixin",

--- a/library/core/crash_info/src/testmod/resources/quilt_crash_info_testmod.mixins.json
+++ b/library/core/crash_info/src/testmod/resources/quilt_crash_info_testmod.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.crash.test.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "AbstractFurnaceBlockEntityMixin",
     "EndCrystalEntityMixin"

--- a/library/core/lifecycle_events/src/main/resources/quilt_lifecycle_events.mixins.json
+++ b/library/core/lifecycle_events/src/main/resources/quilt_lifecycle_events.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.lifecycle.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "MinecraftServerMixin",
     "ServerWorldMixin"

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/ServerPlayNetworkHandlerMixin.java
@@ -36,8 +36,9 @@ import org.quiltmc.qsl.networking.impl.DisconnectPacketSource;
 import org.quiltmc.qsl.networking.impl.NetworkHandlerExtensions;
 import org.quiltmc.qsl.networking.impl.server.ServerPlayNetworkAddon;
 
-// We want to apply a bit earlier than other mods which may not use us in order to prevent refCount issues
-@Mixin(value = ServerPlayNetworkHandler.class, priority = 999)
+// We want to apply a bit earlier than other mods which may not use us in order to prevent refCount issues.
+// Technically this is the default priority in QSL, but we'll leave this here just in case.
+@Mixin(value = ServerPlayNetworkHandler.class, priority = 500)
 abstract class ServerPlayNetworkHandlerMixin implements NetworkHandlerExtensions, DisconnectPacketSource {
 	@Shadow
 	@Final

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -35,9 +35,10 @@ import org.quiltmc.qsl.networking.impl.NetworkHandlerExtensions;
 import org.quiltmc.qsl.networking.impl.client.ClientNetworkingImpl;
 import org.quiltmc.qsl.networking.impl.client.ClientPlayNetworkAddon;
 
-// We want to apply a bit earlier than other mods which may not use us in order to prevent refCount issues
+// We want to apply a bit earlier than other mods which may not use us in order to prevent refCount issues.
+// Technically this is the default priority in QSL, but we'll leave this here just in case.
 @ClientOnly
-@Mixin(value = ClientPlayNetworkHandler.class, priority = 999)
+@Mixin(value = ClientPlayNetworkHandler.class, priority = 500)
 abstract class ClientPlayNetworkHandlerMixin implements NetworkHandlerExtensions {
 	@Final
 	@Shadow

--- a/library/core/networking/src/main/resources/quilt_networking.mixins.json
+++ b/library/core/networking/src/main/resources/quilt_networking.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.networking.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "ClientConnectionMixin",
     "EntityTrackerEntryMixin",

--- a/library/core/qsl_base/src/main/resources/quilt_base.mixins.json
+++ b/library/core/qsl_base/src/main/resources/quilt_base.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.base.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "BootstrapAccessor",
     "MinecraftServerMixin",

--- a/library/core/registry/src/main/resources/quilt_registry.mixins.json
+++ b/library/core/registry/src/main/resources/quilt_registry.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.registry.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "BlocksMixin",
     "RegistriesMixin",

--- a/library/core/resource_loader/src/main/resources/quilt_resource_loader.mixins.json
+++ b/library/core/resource_loader/src/main/resources/quilt_resource_loader.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.resource.loader.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "BuiltinResourcePackProviderMixin",
     "IdentifierAccessor",

--- a/library/core/testing/src/main/resources/quilt_testing.mixins.json
+++ b/library/core/testing/src/main/resources/quilt_testing.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.testing.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "MinecraftServerMixin",
     "StructureTemplateManagerMixin",

--- a/library/data/recipe/src/main/resources/quilt_recipe.mixins.json
+++ b/library/data/recipe/src/main/resources/quilt_recipe.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.recipe.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "LegacySmithingRecipeSerializerMixin",
     "TransformSmithingRecipeAccessor",

--- a/library/data/registry_entry_attachment/src/main/resources/quilt_registry_entry_attachment.mixins.json
+++ b/library/data/registry_entry_attachment/src/main/resources/quilt_registry_entry_attachment.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.registry.attachment.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "RegistryKeyMixin"
   ],

--- a/library/data/registry_entry_attachment/src/testmod/resources/quilt_registry_entry_attachment_testmod.mixins.json
+++ b/library/data/registry_entry_attachment/src/testmod/resources/quilt_registry_entry_attachment_testmod.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.registry.attachment.test.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "client": [
     "client.DebugHudMixin"
   ],

--- a/library/data/tags/src/main/resources/quilt_tags.mixins.json
+++ b/library/data/tags/src/main/resources/quilt_tags.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.tag.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "SimpleRegistryMixin",
     "TagKeyAccessor",

--- a/library/entity/entity/src/main/resources/quilt_entity.mixins.json
+++ b/library/entity/entity/src/main/resources/quilt_entity.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.entity.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "DefaultAttributeRegistryMixin"
   ],

--- a/library/entity/entity_events/src/main/resources/quilt_entity_events.mixins.json
+++ b/library/entity/entity_events/src/main/resources/quilt_entity_events.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.entity.event.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "EntityMixin",
     "LivingEntityDeathEventMixin",

--- a/library/entity/entity_networking/src/main/resources/quilt_entity_networking.mixins.json
+++ b/library/entity/entity_networking/src/main/resources/quilt_entity_networking.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.entity.networking.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "TrackedDataHandlerRegistryMixin"
   ],

--- a/library/entity/entity_networking/src/testmod/resources/quilt_entity_networking_testmod.mixins.json
+++ b/library/entity/entity_networking/src/testmod/resources/quilt_entity_networking_testmod.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.entity.networking.test.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "CreeperEntityMixin"
   ],

--- a/library/entity/multipart/src/main/resources/quilt_entity_multipart.mixins.json
+++ b/library/entity/multipart/src/main/resources/quilt_entity_multipart.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.entity.multipart.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "EnderDragonEntityMixin",
     "EnderDragonPartMixin",

--- a/library/entity/multipart/src/testmod/resources/quilt_entity_multipart_testmod.mixins.json
+++ b/library/entity/multipart/src/testmod/resources/quilt_entity_multipart_testmod.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.entity.multipart.test.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "CreeperEntityMixin"
   ],

--- a/library/entity/point_of_interest/src/main/resources/quilt_point_of_interest.mixins.json
+++ b/library/entity/point_of_interest/src/main/resources/quilt_point_of_interest.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.poi.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "PointOfInterestTypeMixin"
   ],

--- a/library/entity/status_effect/src/main/resources/quilt_status_effect.mixins.json
+++ b/library/entity/status_effect/src/main/resources/quilt_status_effect.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.entity.effect.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "EffectCommandMixin",
     "LivingEntityMixin",

--- a/library/entity/vehicle/src/main/resources/quilt_vehicle.mixins.json
+++ b/library/entity/vehicle/src/main/resources/quilt_vehicle.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.vehicle.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "AbstractMinecartEntityMixin",
     "DetectorRailBlockMixin"

--- a/library/entity/vehicle/src/testmod/resources/quilt_vehicle_testmod.mixins.json
+++ b/library/entity/vehicle/src/testmod/resources/quilt_vehicle_testmod.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.vehicle.test.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "TntMinecartEntityMixin"
   ],

--- a/library/entity/villager/src/main/resources/quilt_villager.mixins.json
+++ b/library/entity/villager/src/main/resources/quilt_villager.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.villager.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "TypeAwareBuyForOneEmeraldFactoryMixin"
   ],

--- a/library/gui/screen/src/main/resources/quilt_screen.mixins.json
+++ b/library/gui/screen/src/main/resources/quilt_screen.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.screen.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "client": [
     "client.GameRendererMixin",
     "client.KeyboardMixin",

--- a/library/gui/tooltip/src/main/resources/quilt_tooltip.mixins.json
+++ b/library/gui/tooltip/src/main/resources/quilt_tooltip.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.tooltip.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "client": [
     "client.ItemStackMixin",
     "client.TooltipComponentMixin"

--- a/library/item/item_content_registry/src/main/resources/quilt_item_content_registry.mixins.json
+++ b/library/item/item_content_registry/src/main/resources/quilt_item_content_registry.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.item.content.registry.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "AbstractFurnaceBlockEntityMixin"
   ],

--- a/library/item/item_extensions/src/main/resources/quilt_item_extensions.mixins.json
+++ b/library/item/item_extensions/src/main/resources/quilt_item_extensions.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.item.extensions.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "ProjectileUtilMixin",
     "bow.AbstractSkeletonEntityMixin",

--- a/library/item/item_group/src/main/resources/quilt_item_group.mixins.json
+++ b/library/item/item_group/src/main/resources/quilt_item_group.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.item.group.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "ItemGroupMixin"
   ],

--- a/library/item/item_setting/src/main/resources/quilt_item_setting.mixins.json
+++ b/library/item/item_setting/src/main/resources/quilt_item_setting.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.item.setting.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "ItemMixin",
     "ItemStackMixin",

--- a/library/item/item_setting/src/testmod/resources/quilt_item_setting_testmod.mixins.json
+++ b/library/item/item_setting/src/testmod/resources/quilt_item_setting_testmod.mixins.json
@@ -1,6 +1,7 @@
 {
   "package": "org.quiltmc.qsl.item.test.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "injectors": {
     "defaultRequire": 1
   },

--- a/library/management/chat/src/main/resources/quilt_chat.mixins.json
+++ b/library/management/chat/src/main/resources/quilt_chat.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.chat.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "client": [
     "client.ClientPlayNetworkHandlerAccessor",
     "client.ClientPlayNetworkHandlerMixin"

--- a/library/management/client_command/src/main/resources/quilt_client_command.mixins.json
+++ b/library/management/client_command/src/main/resources/quilt_client_command.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.command.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "client": [
     "HelpCommandAccessor",
     "client.ClientCommandSourceMixin",

--- a/library/management/command/src/main/resources/quilt_command.mixins.json
+++ b/library/management/command/src/main/resources/quilt_command.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.command.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "ArgumentTypeInfosAccessor",
     "CommandManagerMixin",

--- a/library/misc/datafixerupper/src/main/resources/quilt_datafixerupper.mixins.json
+++ b/library/misc/datafixerupper/src/main/resources/quilt_datafixerupper.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.datafixerupper.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "ChunkSerializerMixin",
     "NbtHelperMixin",

--- a/library/rendering/entity_rendering/src/main/resources/quilt_entity_rendering.mixins.json
+++ b/library/rendering/entity_rendering/src/main/resources/quilt_entity_rendering.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.rendering.entity.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "client": [
     "client.ArmorFeatureRendererMixin",
     "client.ArmorMaterialMixin",

--- a/library/rendering/entity_rendering/src/testmod/resources/quilt_entity_rendering_testmod.mixins.json
+++ b/library/rendering/entity_rendering/src/testmod/resources/quilt_entity_rendering_testmod.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.rendering.entity.test.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "ArmorItemMixin"
   ],

--- a/library/worldgen/biome/src/main/resources/quilt_biome.mixins.json
+++ b/library/worldgen/biome/src/main/resources/quilt_biome.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.worldgen.biome.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "C_xmtsvelxMixin",
     "ChunkNoiseSamplerMixin",

--- a/library/worldgen/dimension/src/main/resources/quilt_dimension.mixins.json
+++ b/library/worldgen/dimension/src/main/resources/quilt_dimension.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.worldgen.dimension.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "EntityMixin",
     "WorldSaveStorageBugfixMixin",

--- a/library/worldgen/surface_rule/src/main/resources/quilt_surface_rule.mixins.json
+++ b/library/worldgen/surface_rule/src/main/resources/quilt_surface_rule.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "org.quiltmc.qsl.worldgen.surface_rule.mixin",
   "compatibilityLevel": "JAVA_17",
+  "mixinPriority": 500,
   "mixins": [
     "ChunkGeneratorSettingsAccessor",
     "SequenceMaterialRuleMixin"


### PR DESCRIPTION
This has a few, somewhat contradictory effects:
- QSL's mixins are applied *before* other mixins
- In the final class, QSLs injection points now ALWAYS occur:
  - After HEAD injections of other mods
  - Before RETURN injections of other mods

This change will **largely eliminate 50/50 incompatibilities with other mods**, Quilt or otherwise. Interactions between a mod and QSL will always either fail or succeed, unless its mixins also apply at 500 priority.

As to why 500 and not 1500 (applying after everything else): The decision was largely arbitrary, but personally I think it makes more sense for the "default mod" to always apply its mixins before the user-installed mods, similar to how Forge works

**IF ACCEPTED, EVERY OPEN PR WHICH ADDS A NEW MODULE WOULD NEED TO BE UPDATED TO INCLUDE THE NEW MIXIN JSON ENTRY**