### PR TITLE
Deprecate equipment slot providers

### DIFF
--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/api/EquipmentSlotProvider.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/api/EquipmentSlotProvider.java
@@ -30,7 +30,10 @@ import net.minecraft.item.ItemStack;
  * <p>
  * Note that items extending {@link net.minecraft.item.ArmorItem} should
  * use {@link ArmorItem#getArmorSlot()} instead.
+ *
+ * @deprecated Implement the {@link net.minecraft.item.Equippable} interface from Minecraft 1.19.4+ in the relevant block/item instead.
  */
+@Deprecated(forRemoval = true)
 @FunctionalInterface
 public interface EquipmentSlotProvider {
 	/**

--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/api/QuiltCustomItemSettings.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/api/QuiltCustomItemSettings.java
@@ -26,6 +26,8 @@ public final class QuiltCustomItemSettings {
 
 	/**
 	 * The {@link CustomItemSetting} in charge of handing {@link EquipmentSlotProvider}s.
+	 *
+	 * @deprecated Implement the {@link net.minecraft.item.Equippable} interface from Minecraft 1.19.4+ in the relevant block/item instead.
 	 */
 	public static final CustomItemSetting<EquipmentSlotProvider> EQUIPMENT_SLOT_PROVIDER = CustomItemSettingImpl.EQUIPMENT_SLOT_PROVIDER;
 

--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/impl/CustomItemSettingImpl.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/impl/CustomItemSettingImpl.java
@@ -37,6 +37,7 @@ import org.quiltmc.qsl.item.setting.api.RecipeRemainderProvider;
 
 @ApiStatus.Internal
 public class CustomItemSettingImpl<T> implements CustomItemSetting<T> {
+	@Deprecated(forRemoval = true)
 	public static final CustomItemSetting<EquipmentSlotProvider> EQUIPMENT_SLOT_PROVIDER = CustomItemSetting.create(() -> null);
 	public static final CustomItemSetting<CustomDamageHandler> CUSTOM_DAMAGE_HANDLER = CustomItemSetting.create(() -> null);
 


### PR DESCRIPTION
It turns out that since Minecraft 1.19.4+, the `Equippable` interface has been fulfilling the purposes of this item setting not only in a way that makes it irrelevant, but in a way that is much more flexible than ever;

I believe that this item setting needs to be removed, and yeah, this unfortunately can't be done on Minecraft 1.20.1; We'll have to wait for the next version instead;

(on an unrelated note, i feel like `Equippable` would benefit a lot from QM documentation here)