### PR TITLE
Make error logging better for bad pack.mcmeta files in mods.

### DIFF
--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/InMemoryResourcePack.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/InMemoryResourcePack.java
@@ -45,7 +45,6 @@ import org.slf4j.Logger;
 
 import net.minecraft.resource.ResourceIoSupplier;
 import net.minecraft.resource.ResourceType;
-import net.minecraft.resource.pack.AbstractFileResourcePack;
 import net.minecraft.resource.pack.ResourcePack;
 import net.minecraft.resource.pack.metadata.ResourceMetadataReader;
 import net.minecraft.util.Identifier;
@@ -53,6 +52,7 @@ import net.minecraft.util.JsonHelper;
 
 import org.quiltmc.loader.api.QuiltLoader;
 import org.quiltmc.qsl.base.api.util.TriState;
+import org.quiltmc.qsl.resource.loader.impl.ResourceLoaderImpl;
 
 /**
  * Represents an in-memory resource pack.
@@ -142,7 +142,7 @@ public abstract class InMemoryResourcePack implements MutableResourcePack {
 		if (resource == null) return null;
 
 		try (var stream = resource.get()) {
-			return AbstractFileResourcePack.parseMetadata(metaReader, stream);
+			return ResourceLoaderImpl.parseMetadata(metaReader, this, stream);
 		}
 	}
 

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModNioResourcePack.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/impl/ModNioResourcePack.java
@@ -35,12 +35,14 @@ import org.slf4j.Logger;
 import net.minecraft.resource.ResourceIoSupplier;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.resource.pack.AbstractFileResourcePack;
+import net.minecraft.resource.pack.ResourcePack;
+import net.minecraft.resource.pack.metadata.ResourceMetadataReader;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 
-import org.quiltmc.loader.api.ModMetadata;
 import org.quiltmc.loader.api.CachedFileSystem;
+import org.quiltmc.loader.api.ModMetadata;
 import org.quiltmc.qsl.base.api.util.TriState;
 import org.quiltmc.qsl.resource.loader.api.QuiltResourcePack;
 import org.quiltmc.qsl.resource.loader.api.ResourcePackActivationType;
@@ -68,9 +70,9 @@ public class ModNioResourcePack extends AbstractFileResourcePack implements Quil
 	/* Caches */
 	private final ResourceAccess cache;
 
-	static ModNioResourcePack ofMod(ModMetadata modInfo, Path path, ResourceType type, @Nullable String name) {
+	static ModNioResourcePack ofMod(ModMetadata modInfo, Path path, ResourceType type) {
 		return new ModNioResourcePack(
-				name, modInfo, null, ResourcePackActivationType.ALWAYS_ENABLED,
+				null, modInfo, null, ResourcePackActivationType.ALWAYS_ENABLED,
 				path, type, null
 		);
 	}
@@ -173,6 +175,19 @@ public class ModNioResourcePack extends AbstractFileResourcePack implements Quil
 				this.closer.close();
 			} catch (Exception e) {
 				throw new RuntimeException(e);
+			}
+		}
+	}
+
+	@Override
+	public <T> @Nullable T parseMetadata(ResourceMetadataReader<T> metaReader) throws IOException {
+		ResourceIoSupplier<InputStream> resource = this.openRoot(ResourcePack.PACK_METADATA_NAME);
+
+		if (resource == null) {
+			return null;
+		} else {
+			try (InputStream stream = resource.get()) {
+				return ResourceLoaderImpl.parseMetadata(metaReader, this, stream);
 			}
 		}
 	}


### PR DESCRIPTION
This was brought up a few days ago by @lukebemish, when some mods with wrongly formatted `pack.mcmeta` were loaded, causing a log spam without a clear cause.

This should allow to identify more easily mods that have a wrongly formatted `pack.mcmeta` by now logging the resource pack name as well.

The way this implementation is made is needed due to not being able to patch the original Minecraft method as it doesn't have enough context on the source resource pack. 