### PR TITLE
Add javadoc publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,23 @@ jobs:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-      - run: ./gradlew build publish --stacktrace
+      - run: ./gradlew build publish fatJavadoc --parallel --stacktrace
         env:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+      # Javadoc publishing
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: 'gh-pages'
+          path: "gh-pages"
+      - run: |
+          rm -rf ./gh-pages/${GITHUB_REF##*/}/
+          mv ./build/docs/fat-javadoc ./gh-pages/${GITHUB_REF##*/}/
+          cd gh-pages
+          git add .
+          git config user.name "GitHub Actions"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit --allow-empty -m "Publish javadoc from actions"
+          git push

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ version = version + "+" + Versions.MINECRAFT_VERSION.version() + (System.getenv(
 println("QSL: " + version)
 
 sourceSets {
+	doclet
 	testmod {
 		compileClasspath += main.compileClasspath
 		runtimeClasspath += main.runtimeClasspath
@@ -49,24 +50,36 @@ jar {
 task fatJavadoc(type: Javadoc) {
 	group "documentation"
 
+	def docletResources = sourceSets.doclet.resources.asFileTree
 	options {
 		source = String.valueOf(Versions.JAVA_VERSION)
 		encoding = "UTF-8"
 		charSet = "UTF-8"
 		memberLevel = JavadocMemberLevel.PACKAGE
+		splitIndex true
 		links(
 				"https://guava.dev/releases/31.1-jre/api/docs/",
 				"https://asm.ow2.io/javadoc/",
 				"https://docs.oracle.com/en/java/javase/17/docs/api/",
 				"https://jenkins.liteloader.com/job/Mixin/javadoc/",
-				"https://maven.quiltmc.org/repository/release/org/quiltmc/quilt-mappings/${Versions.MINECRAFT_VERSION.version()}+build.${Versions.MAPPINGS_BUILD}/quilt-mappings-${Versions.MINECRAFT_VERSION.version()}+build.${Versions.MAPPINGS_BUILD}-javadoc.jar/"
+				"https://javadoc.quiltmc.org/quilt-mappings/${Versions.MINECRAFT_VERSION.version()}/"
 		)
 
-		// Disable the overzealous doclint tool in Java 8
-		addStringOption("Xdoclint:none", "-quiet")
+
+		addBooleanOption 'Xdoclint:html', true
+		addBooleanOption 'Xdoclint:syntax', true
+		addBooleanOption 'Xdoclint:reference', true
+		addBooleanOption 'Xdoclint:accessibility', true
+		addStringOption("-notimestamp")
+		addStringOption("Xdoclint:none")
+		addStringOption("-quiet")
+		addFileOption "-add-stylesheet", docletResources.filter { it.name == 'style.css' }.singleFile
 		tags(
 				"author:a",
-				'reason:m:"Reason:"'
+				'reason:m:"Reason:"',
+				'apiNote:a:API Note:',
+				'implSpec:a:Implementation Requirements:',
+				'implNote:a:Implementation Note:'
 		)
 	}
 
@@ -74,6 +87,13 @@ task fatJavadoc(type: Javadoc) {
 
 	exclude {
 		it.file.absolutePath.contains("mixin") || it.file.absolutePath.contains("impl")
+	}
+
+	doLast {
+		project.copy {
+			from docletResources
+			into fatJavadoc.outputDirectory
+		}
 	}
 
 	afterEvaluate {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/doclet/resources/style.css
+++ b/src/doclet/resources/style.css
@@ -1,0 +1,156 @@
+/* Quilt Additions */
+
+@import url('https://fonts.bunny.net/css?family=Poppins:500,700&display=swap');
+
+:root {
+    --quilt_theme_background: #fefcff;
+    --quilt_theme_foreground: #4a4a4a;
+
+    --quilt_theme_selected_background: #9722ff;
+
+    --quilt_theme_background_code: #77778022;
+    --quilt_theme_link_color: #27a2fd;
+    --quilt_theme_link_hover_color: #1571b7;
+    --quilt_theme_border_color: #777;
+
+    --quilt_theme_navbar_background: #f9f3ff;
+    --quilt_theme_navbar_foreground: rgba(7, 6, 6, 0.7);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --quilt_theme_background: #271f33;
+        --quilt_theme_foreground: #fafafa;
+
+        --quilt_theme_link_hover_color: #026cbb;
+
+        --quilt_theme_navbar_background: #1c1526;
+        --quilt_theme_navbar_foreground: white;
+    }
+}
+
+.quilt {
+    font: 400 14px/1.5 -apple-system, system-ui, sans-serif;
+    color: var(--quilt_theme_foreground);
+    background-color: var(--quilt_theme_background);
+    -webkit-text-size-adjust: 100%;
+    -webkit-font-feature-settings: "kern" 1;
+    -moz-font-feature-settings: "kern" 1;
+    -o-font-feature-settings: "kern" 1;
+    font-feature-settings: "kern" 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.quilt table {
+    width: 100%;
+    text-align: left;
+    color: var(--quilt_theme_foreground);
+    border-collapse: collapse;
+    border: 1px solid var(--quilt_theme_border_color);
+}
+
+.quilt table tr:nth-child(even) {
+    background-color: var(--quilt_theme_navbar_background);
+}
+
+.quilt table th, table td {
+    padding: 1px 10px;
+}
+
+.quilt table th {
+    background-color: var(--quilt_theme_navbar_background);
+    border: 1px solid var(--quilt_theme_border_color);
+    border-bottom-color: var(--quilt_theme_border_color);
+}
+
+.quilt table td {
+    border: 1px solid var(--quilt_theme_border_color);
+}
+
+/* Changes */
+
+body, div.block , dl.notes > dd {
+    font-family: -apple-system, system-ui, sans-serif;
+    font-size: medium;
+}
+
+body, .even-row-color, .even-row-color .table-header,
+.summary section[class$="-summary"], .details section[class$="-details"], .class-uses .detail, .serialized-class-details,
+.inherited-list, section[class$="-details"] .detail,
+#search-input {
+    background-color: var(--quilt_theme_background);
+    color: var(--quilt_theme_foreground);
+}
+
+.ui-widget-content {
+    background-color: var(--quilt_theme_background) !important;
+    color: var(--quilt_theme_foreground) !important;
+}
+
+.top-nav, .sub-nav, .nav-bar-cell1-rev {
+    font-family: "Poppins", sans-serif;
+}
+
+a:link, a:visited {
+    color: var(--quilt_theme_link_color);
+}
+
+a[href]:hover, a[href]:focus {
+    color: var(--quilt_theme_link_hover_color);
+}
+
+.block, .title, dl.notes > dt {
+    color: var(--quilt_theme_foreground);
+}
+
+:not(h1, h2, h3, h4, h5, h6) > code {
+    font-family: ui-monospace, monospace;
+    font-size: 85%;
+}
+
+:not(pre) > code {
+    background-color: var(--quilt_theme_background_code);
+    border-radius: 6px;
+    padding: .2em .4em;
+}
+
+.top-nav, .sub-nav, .table-header, .odd-row-color, .odd-row-color .table-header,
+body.class-declaration-page .summary h3, body.class-declaration-page .details h3,
+body.class-declaration-page .summary .inherited-list h2,
+.ui-autocomplete-category {
+    background-color: var(--quilt_theme_navbar_background);
+    color: var(--quilt_theme_navbar_foreground);
+}
+
+.ui-state-active,
+.ui-widget-content .ui-state-active,
+.ui-widget-header .ui-state-active,
+a.ui-button:active,
+.ui-button:active,
+.ui-button.ui-state-active:hover {
+    background-color: var(--quilt_theme_selected_background) !important;
+    color: white !important;
+}
+
+.top-nav a:link, .top-nav a:active, .top-nav a:visited {
+    color: var(--quilt_theme_navbar_foreground);
+}
+
+.caption, .nav-bar-cell1-rev, div.table-tabs > button.active-table-tab {
+    color: white;
+}
+
+.caption span, .nav-bar-cell1-rev, div.table-tabs > button.active-table-tab {
+    background-color: var(--quilt_theme_selected_background);
+}
+
+.summary-table, .details-table,
+.summary section[class$="-summary"], .details section[class$="-details"], .class-uses .detail, .serialized-class-details,
+#search-input {
+    border-color: var(--quilt_theme_border_color);
+}
+
+.col-first, .col-second, .col-last, .col-constructor-name, .col-summary-item-name, .col-last {
+    font-size: medium;
+}


### PR DESCRIPTION
This would (currently pending admin setup for the domain name) publish the latest version of QSL's javadoc at `javadoc.quiltmc.org/quilt-standard-libraries/{MC_VER}`.

Before merge, someone will have to set up the gh-pages branch:
`git switch --orphan gh-pages`
`git commit --allow-empty -m "root commit for javadoc"`
`git push`