### PR TITLE
Update to QLoader 0.20.1, migrate RegSync config to `ReflectiveConfig`

### DIFF
--- a/build-logic/src/main/java/qsl/internal/Versions.java
+++ b/build-logic/src/main/java/qsl/internal/Versions.java
@@ -43,7 +43,7 @@ public final class Versions {
 	/**
 	 * The version of Quilt Loader to use.
 	 */
-	public static final String LOADER_VERSION = "0.19.2";
+	public static final String LOADER_VERSION = "0.20.1";
 
 	/**
 	 * The target Java version.

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/RegistryConfig.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/RegistryConfig.java
@@ -16,70 +16,66 @@
 
 package org.quiltmc.qsl.registry.impl;
 
-import java.util.List;
-
 import org.jetbrains.annotations.ApiStatus;
 
 import net.minecraft.text.Text;
 
-import org.quiltmc.config.api.WrappedConfig;
+import org.quiltmc.config.api.ReflectiveConfig;
 import org.quiltmc.config.api.annotations.Comment;
-import org.quiltmc.loader.api.config.QuiltConfig;
+import org.quiltmc.config.api.values.TrackedValue;
+import org.quiltmc.loader.api.config.v2.QuiltConfig;
 
 @ApiStatus.Internal
-public class RegistryConfig extends WrappedConfig {
+public class RegistryConfig extends ReflectiveConfig {
 	public static final RegistryConfig INSTANCE = QuiltConfig.create("quilt/qsl", "registry", RegistryConfig.class);
 
 	public final RegistrySync registry_sync = new RegistrySync();
 
-	// This is just workaround for direct values from INSTANCE not being correct.
-	@Deprecated
-	public static Object getSync(String key) {
-		return RegistryConfig.INSTANCE.getValue(List.of("registry_sync", key)).value();
-	}
-
-	public static class RegistrySync implements Section {
-		@Comment("Mod protocol is a feature allowing you to prevent clients with mismatched settings to join.")
-		@Comment("Client with mismatched values won't be able to connect to servers having this enabled.")
-		@Comment("It should be used only for non-vanilla compatible modpacks!")
-		@Comment("Protocol version. Needs to be the same on client and server. If it has value of -1, it won't be required by servers.")
-		public final int mod_protocol_version = -1;
+	public static class RegistrySync extends Section {
+		@Comment("""
+		Mod protocol is a feature allowing you to prevent clients with mismatched settings to join.
+		Client with mismatched values won't be able to connect to servers having this enabled.
+		It should be used only for non-vanilla compatible modpacks!
+		Protocol version. Needs to be the same on client and server. If it has value of -1, it won't be required by servers.
+		""")
+		public final TrackedValue<Integer> mod_protocol_version = value(-1);
 		@Comment("Protocol id. It should be different for every modpack, to prevent joining with mismatched mods.")
-		public final String mod_protocol_id = "my_quilt_modpack";
+		public final TrackedValue<String> mod_protocol_id = value("my_quilt_modpack");
 		@Comment("A mod protocol name. Used for easier identification. Doesn't effect functionality")
-		public final String mod_protocol_name = "My Quilt Modpack";
+		public final TrackedValue<String> mod_protocol_name = value("My Quilt Modpack");
 
 
 		@Comment("Message displayed for players joining with clients incompatible with Registry Sync. Supports strings and Minecraft's JSON text format.")
-		public final String missing_registry_sync_message = Text.Serializer.toJson(Text.translatableWithFallback("qsl.registry_sync.unsupported_client", """
+		public final TrackedValue<String> missing_registry_sync_message = value(Text.Serializer.toJson(Text.translatableWithFallback("qsl.registry_sync.unsupported_client", """
 				Unsupported (vanilla?) client!
-				This server requires modded client to join!"""));
+				This server requires modded client to join!
+				""")));
 
 		@Comment("Top part of the message displayed for players joining with incompatible clients. Supports strings and Minecraft's JSON text format.")
-		public final String mismatched_entries_top_message = Text.Serializer.toJson(Text.translatableWithFallback("qsl.registry_sync.failed_sync", """
+		public final TrackedValue<String> mismatched_entries_top_message = value(Text.Serializer.toJson(Text.translatableWithFallback("qsl.registry_sync.failed_sync", """
 				Failed to synchronize client with the server!
 				This can happen when client's and server's mods don't match.
-				"""));
+				""")));
 
 		@Comment("Bottom part of the message displayed for players joining with incompatible clients. Supports strings and Minecraft's JSON text format.")
-		public final String mismatched_entries_bottom_message = "";
+		public final TrackedValue<String> mismatched_entries_bottom_message = value("");
 
 		@Comment("Shows some details about why client couldn't connect.")
-		public final boolean mismatched_entries_show_details = true;
+		public final TrackedValue<Boolean> mismatched_entries_show_details = value(true);
 
 		@Comment("Allows players with Fabric API to connect, as long as they have all required mods.")
-		public final boolean support_fabric_api_protocol = true;
+		public final TrackedValue<Boolean> support_fabric_api_protocol = value(true);
 
 		@Comment("Forces unknown clients to use the Fabric Registry Sync protocol fallback. Disables preventing Vanilla clients from joining.")
-		public final boolean force_fabric_api_protocol_fallback = false;
+		public final TrackedValue<Boolean> force_fabric_api_protocol_fallback = value(false);
 
 		@Comment("Disables the Mod Protocol sync on server list/initial query.")
-		public final boolean disable_mod_protocol_ping = false;
+		public final TrackedValue<Boolean> disable_mod_protocol_ping = value(false);
 
 		@Comment("Disables the Registry Sync requirement. USE AT YOUR OWN RISK!")
-		public final boolean disable_registry_sync = false;
+		public final TrackedValue<Boolean> disable_registry_sync = value(false);
 
 		@Comment("Disables validation of (block/fluid) states. USE AT YOUR OWN RISK!")
-		public final boolean disable_state_validation = false;
+		public final TrackedValue<Boolean> disable_state_validation = value(false);
 	}
 }

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/sync/mod_protocol/ModProtocolImpl.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/sync/mod_protocol/ModProtocolImpl.java
@@ -44,14 +44,11 @@ public class ModProtocolImpl {
 
 	@SuppressWarnings("ConstantConditions")
 	public static void loadVersions() {
-		//var modProto = RegistryConfig.INSTANCE.registry_sync;
-		//disableQuery = modProto.disable_mod_protocol_ping;
-		disableQuery = (Boolean) RegistryConfig.getSync("disable_mod_protocol_ping");
+		var config = RegistryConfig.INSTANCE.registry_sync;
+		disableQuery = config.disable_mod_protocol_ping.value();
 
-		//if (modProto.mod_protocol_version >= 0) {
-		if (((Number) RegistryConfig.getSync("mod_protocol_version")).intValue() >= 0) {
-			//prioritizedEntry = new ModProtocolDef("global:" + modProto.mod_protocol_id, modProto.mod_protocol_name, IntList.of(modProto.mod_protocol_version), false);
-			prioritizedEntry = new ModProtocolDef("global:" + (String) RegistryConfig.getSync("mod_protocol_id"), (String) RegistryConfig.getSync("mod_protocol_name"), IntList.of(((Number) RegistryConfig.getSync("mod_protocol_version")).intValue()), false);
+		if (config.mod_protocol_version.value() >= 0) {
+			prioritizedEntry = new ModProtocolDef("global:" + config.mod_protocol_id.value(), config.mod_protocol_name.value(), IntList.of(config.mod_protocol_version.value()), false);
 			prioritizedId = prioritizedEntry.id();
 			add(prioritizedEntry);
 		}

--- a/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/sync/server/ServerRegistrySync.java
+++ b/library/core/registry/src/main/java/org/quiltmc/qsl/registry/impl/sync/server/ServerRegistrySync.java
@@ -68,26 +68,17 @@ public final class ServerRegistrySync {
 	public static IntList SERVER_SUPPORTED_PROTOCOL = new IntArrayList(ProtocolVersions.IMPL_SUPPORTED_VERSIONS);
 
 	public static void readConfig() {
-		/*var config = RegistryConfig.INSTANCE.registry_sync;
+		var config = RegistryConfig.INSTANCE.registry_sync;
 
-		noRegistrySyncMessage = text(config.missing_registry_sync_message);
-		errorStyleHeader = text(config.mismatched_entries_top_message);
-		errorStyleFooter = text(config.mismatched_entries_bottom_message);
+		noRegistrySyncMessage = text(config.missing_registry_sync_message.value());
+		errorStyleHeader = text(config.mismatched_entries_top_message.value());
+		errorStyleFooter = text(config.mismatched_entries_bottom_message.value());
 
-		supportFabric = config.support_fabric_api_protocol;
-		forceFabricFallback = config.force_fabric_api_protocol_fallback;
-		forceDisable = config.disable_registry_sync;
-		showErrorDetails = config.mismatched_entries_show_details;
-		*/
-		noRegistrySyncMessage = text((String) RegistryConfig.getSync("missing_registry_sync_message"));
-		errorStyleHeader = text((String) RegistryConfig.getSync("mismatched_entries_top_message"));
-		errorStyleFooter = text((String) RegistryConfig.getSync("mismatched_entries_bottom_message"));
-
-		supportFabric = (Boolean) RegistryConfig.getSync("support_fabric_api_protocol");
-		forceFabricFallback = (Boolean) RegistryConfig.getSync("force_fabric_api_protocol_fallback");
-		forceDisable = (Boolean) RegistryConfig.getSync("disable_registry_sync");
-		showErrorDetails = (Boolean) RegistryConfig.getSync("mismatched_entries_show_details");
-		stateValidation = !(Boolean) RegistryConfig.getSync("disable_state_validation");
+		supportFabric = config.support_fabric_api_protocol.value();
+		forceFabricFallback = config.force_fabric_api_protocol_fallback.value();
+		forceDisable = config.disable_registry_sync.value();
+		showErrorDetails = config.mismatched_entries_show_details.value();
+		stateValidation = !config.disable_state_validation.value();
 
 		if (stateValidation) {
 			for (var container : QuiltLoader.getAllMods()) {


### PR DESCRIPTION
This PR takes advantages of Quilt Loader 0.20.1's new config API in order to get rid a lot of Quilt Registry Sync's janky code that worked around `WrappedConfig`'s fundamental flaw

(~~there was an attempt to add labels to this PR but uh, terrible internet connection won't let me to and i need to wake up earlier tomorrow~~ update: nvm)