### PR TITLE
Add missing null handling to `GroupResourcePack`

### DIFF
--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/GroupResourcePack.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/GroupResourcePack.java
@@ -77,7 +77,13 @@ public abstract class GroupResourcePack implements ResourcePack {
 	 * @return the list of the matching resource packs
 	 */
 	public @UnmodifiableView List<? extends ResourcePack> getPacks(String namespace) {
-		return Collections.unmodifiableList(this.namespacedPacks.getOrDefault(namespace, Collections.emptyList()));
+		var packs = this.namespacedPacks.get(namespace);
+
+		if (packs != null) {
+			return Collections.unmodifiableList(packs);
+		}
+
+		return Collections.emptyList();
 	}
 
 	/**

--- a/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/GroupResourcePack.java
+++ b/library/core/resource_loader/src/main/java/org/quiltmc/qsl/resource/loader/api/GroupResourcePack.java
@@ -77,7 +77,7 @@ public abstract class GroupResourcePack implements ResourcePack {
 	 * @return the list of the matching resource packs
 	 */
 	public @UnmodifiableView List<? extends ResourcePack> getPacks(String namespace) {
-		return Collections.unmodifiableList(this.namespacedPacks.get(namespace));
+		return Collections.unmodifiableList(this.namespacedPacks.getOrDefault(namespace, Collections.emptyList()));
 	}
 
 	/**
@@ -131,9 +131,11 @@ public abstract class GroupResourcePack implements ResourcePack {
 			ResourcePack.ResourceConsumer consumer) {
 		var packs = this.namespacedPacks.get(namespace);
 
-		// Iterating backwards as higher-priority packs are placed at the end.
-		for (var pack : packs) {
-			pack.listResources(type, namespace, startingPath, consumer);
+		if (packs != null) {
+			// Iterating backwards as higher-priority packs are placed at the end.
+			for (var pack : packs) {
+				pack.listResources(type, namespace, startingPath, consumer);
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, two methods in `GroupResourcePack` will throw `NullPointerException`s if there is no pack for the given namespace. I've tweaked these methods so that the `GroupResourcePack` won't crash the game in these circumstances.

This isn't an issue when no other mods are present because vanilla also scans packs by namespace. However, I develop a mod that originally listed resources in all packs, regardless of whether they contained a particular namespace, which caused the game to crash.

There's an existing null check in `open()`; this PR makes null handling consistent throughout the whole `GroupResourcePack`.