### PR TITLE
Update RecipeManagerMixin.java

### DIFF
--- a/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/RecipeManagerMixin.java
+++ b/library/item/item_setting/src/main/java/org/quiltmc/qsl/item/setting/mixin/recipe_remainder/RecipeManagerMixin.java
@@ -27,6 +27,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeHolder;
 import net.minecraft.recipe.RecipeManager;
 import net.minecraft.recipe.RecipeType;
 import net.minecraft.util.collection.DefaultedList;
@@ -37,9 +38,9 @@ import org.quiltmc.qsl.item.setting.api.RecipeRemainderProvider;
 @Mixin(RecipeManager.class)
 public class RecipeManagerMixin {
 	@Inject(method = "getRemainingStacks", at = @At(value = "RETURN", ordinal = 0), cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
-	public <C extends Inventory, T extends Recipe<C>> void interceptGetRemainingStacks(RecipeType<T> recipeType, C inventory, World world, CallbackInfoReturnable<DefaultedList<ItemStack>> cir, Optional<Recipe<?>> optionalRecipe) {
+	public <C extends Inventory, T extends Recipe<C>> void interceptGetRemainingStacks(RecipeType<T> recipeType, C inventory, World world, CallbackInfoReturnable<DefaultedList<ItemStack>> cir, Optional<RecipeHolder<?>> optionalRecipe) {
 		cir.setReturnValue(
-				RecipeRemainderProvider.getRemainingStacks(inventory, optionalRecipe.get(), cir.getReturnValue())
+				RecipeRemainderProvider.getRemainingStacks(inventory, optionalRecipe.get().value(), cir.getReturnValue())
 		);
 	}
 }


### PR DESCRIPTION
Fixes the crash while crafting. Recipes in the RecipeManager are referred to with `RecipeHolder`s now, which contain both the `Recipe` and the `Identifier`. We may want to swap to using them for the added information of the `Identifier`, but that would be a breaking API change.