### PR TITLE
Fix Quilt clients being unable to connect to Quilt servers

### DIFF
--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/client/ClientNetworkingImpl.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/client/ClientNetworkingImpl.java
@@ -136,7 +136,9 @@ public final class ClientNetworkingImpl {
 		ClientConfigurationConnectionEvents.DISCONNECT.register((handler, client) -> {
 			currentConfigurationAddon = null;
 		});
-		
+
+		PayloadTypeRegistry.configurationS2C().register(CommonVersionPayload.PACKET_ID, CommonVersionPayload.CODEC);
+		PayloadTypeRegistry.configurationS2C().register(CommonRegisterPayload.PACKET_ID, CommonRegisterPayload.CODEC);
 		PayloadTypeRegistry.playS2C().register(CommonVersionPayload.PACKET_ID, CommonVersionPayload.CODEC);
 		PayloadTypeRegistry.playS2C().register(CommonRegisterPayload.PACKET_ID, CommonRegisterPayload.CODEC);
 

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/client/ClientNetworkingImpl.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/client/ClientNetworkingImpl.java
@@ -136,9 +136,7 @@ public final class ClientNetworkingImpl {
 		ClientConfigurationConnectionEvents.DISCONNECT.register((handler, client) -> {
 			currentConfigurationAddon = null;
 		});
-
-		PayloadTypeRegistry.configurationS2C().register(CommonVersionPayload.PACKET_ID, CommonVersionPayload.CODEC);
-		PayloadTypeRegistry.configurationS2C().register(CommonRegisterPayload.PACKET_ID, CommonRegisterPayload.CODEC);
+		
 		PayloadTypeRegistry.playS2C().register(CommonVersionPayload.PACKET_ID, CommonVersionPayload.CODEC);
 		PayloadTypeRegistry.playS2C().register(CommonRegisterPayload.PACKET_ID, CommonRegisterPayload.CODEC);
 

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/common/CommonPacketsImpl.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/common/CommonPacketsImpl.java
@@ -44,9 +44,7 @@ public class CommonPacketsImpl {
 
 	public static void init(ModContainer mod) {
 		PayloadTypeRegistry.configurationC2S().register(CommonVersionPayload.PACKET_ID, CommonVersionPayload.CODEC);
-		PayloadTypeRegistry.configurationS2C().register(CommonVersionPayload.PACKET_ID, CommonVersionPayload.CODEC);
 		PayloadTypeRegistry.configurationC2S().register(CommonRegisterPayload.PACKET_ID, CommonRegisterPayload.CODEC);
-		PayloadTypeRegistry.configurationS2C().register(CommonRegisterPayload.PACKET_ID, CommonRegisterPayload.CODEC);
 		PayloadTypeRegistry.playC2S().register(CommonVersionPayload.PACKET_ID, CommonVersionPayload.CODEC);
 		PayloadTypeRegistry.playC2S().register(CommonRegisterPayload.PACKET_ID, CommonRegisterPayload.CODEC);
 

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/common/CommonPacketsImpl.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/impl/common/CommonPacketsImpl.java
@@ -44,7 +44,9 @@ public class CommonPacketsImpl {
 
 	public static void init(ModContainer mod) {
 		PayloadTypeRegistry.configurationC2S().register(CommonVersionPayload.PACKET_ID, CommonVersionPayload.CODEC);
+		PayloadTypeRegistry.configurationS2C().register(CommonVersionPayload.PACKET_ID, CommonVersionPayload.CODEC);
 		PayloadTypeRegistry.configurationC2S().register(CommonRegisterPayload.PACKET_ID, CommonRegisterPayload.CODEC);
+		PayloadTypeRegistry.configurationS2C().register(CommonRegisterPayload.PACKET_ID, CommonRegisterPayload.CODEC);
 		PayloadTypeRegistry.playC2S().register(CommonVersionPayload.PACKET_ID, CommonVersionPayload.CODEC);
 		PayloadTypeRegistry.playC2S().register(CommonRegisterPayload.PACKET_ID, CommonRegisterPayload.CODEC);
 

--- a/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/client/ClientConfigurationNetworkHandlerMixin.java
+++ b/library/core/networking/src/main/java/org/quiltmc/qsl/networking/mixin/client/ClientConfigurationNetworkHandlerMixin.java
@@ -50,6 +50,7 @@ abstract class ClientConfigurationNetworkHandlerMixin extends AbstractClientNetw
 		this.addon = new ClientConfigurationNetworkAddon((ClientConfigurationNetworkHandler) (Object) this, this.client);
 		// A bit of a hack but it allows the field above to be set in case someone registers handlers during INIT event which refers to said field
 		ClientNetworkingImpl.setClientConfigurationAddon(this.addon);
+		this.addon.lateInit();
 	}
 
 	@Inject(method = "onFinishConfiguration", at = @At(value = "NEW", target = "(Lnet/minecraft/client/MinecraftClient;Lnet/minecraft/network/ClientConnection;Lnet/minecraft/client/network/ClientConnectionState;)Lnet/minecraft/client/network/ClientPlayNetworkHandler;"))


### PR DESCRIPTION
This fixes two things that were preventing Quilt Clients from joining Quilt Servers due to failed registry sync:

1. `ClientConfigurationNetworkAddon#lateInit()` was never called in `ClientConfigurationNetworkHandlerMixin`, preventing the necessary channels for registry sync from being registered on the client
2. The common version and registry payload codecs were being registered for server-to-client traffic in `ClientNetworkingImpl` rather than `CommonPacketsImpl` (Fabric registers them in their equivalent of the latter).